### PR TITLE
Allowing Runtime#observe to take a single query instead of only an array.

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -70,6 +70,10 @@ Runtime.prototype.observe = function(queries, cb) {
   var filters = [];
   var observable = this._observable;
 
+  if (!Array.isArray(queries)) {
+    queries = [queries];
+  }
+
   if(Object.keys(this._jsDevices).length) {
     var existingDeviceObservable = Rx.Observable.create(function(observer) {
       Object.keys(self._jsDevices).forEach(function(deviceId) {

--- a/test/test_runtime.js
+++ b/test/test_runtime.js
@@ -96,6 +96,18 @@ describe('Runtime', function(){
     });
 
     describe('Runtime#observe', function() {
+      it('will take a single query as the first argument', function(done) {
+        var q = runtime.where({ type: 'test' });
+        var d = { type: 'test' };
+
+        runtime.observe(q, function(device) {
+          assert.equal(device.type, 'test');
+          done();
+        });
+
+        runtime.emit('deviceready', d);
+      });
+
       it('will call the observe callback when the query is fullfilled.', function(done) {
         var q = runtime.where({type: 'test'});
         var d = { type: 'test' };


### PR DESCRIPTION
Just a small bug.
