### PR TITLE
Allowing for state-free sensor drivers.

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -36,16 +36,18 @@ Device.prototype._generate = function(config) {
   this._transitions = config.transitions;
   this._allowed = config.allowed;
 
-  var stateStream = self._createStream('state', ObjectStream);
-  Object.defineProperty(this, 'state', {
-    get: function(){
-      return self._state;
-    },
-    set: function(newValue){
-      self._state = newValue;
-      stateStream.write(newValue);
-    }
-  });
+  if (Object.keys(this._transitions).length) {
+    var stateStream = self._createStream('state', ObjectStream);
+    Object.defineProperty(this, 'state', {
+      get: function(){
+        return self._state;
+      },
+      set: function(newValue){
+        self._state = newValue;
+        stateStream.write(newValue);
+      }
+    });
+  }
   
   this._monitors = [];
   config.monitors.forEach(function(name) {

--- a/test/fixture/sensor_driver.js
+++ b/test/fixture/sensor_driver.js
@@ -1,0 +1,13 @@
+var Runtime = require('../../zetta_runtime');
+var Device = Runtime.Device;
+var util = require('util');
+
+var SensorDriver = module.exports = function(){
+  Device.call(this);
+};
+util.inherits(SensorDriver, Device);
+
+SensorDriver.prototype.init = function(config) {
+  config
+    .type('sensordriver');
+};

--- a/test/test_driver.js
+++ b/test/test_driver.js
@@ -3,9 +3,9 @@ var Logger = require('../lib/logger');
 var Runtime = require('../zetta_runtime');
 var Scientist = require('../lib/scientist');
 var assert = require('assert');
+var SensorDriver = require('./fixture/sensor_driver');
 var TestDriver = require('./fixture/example_driver');
 var MemRegistry = require('./fixture/mem_registry');
-
 
 describe('Driver', function() {
   var machine = null;
@@ -155,6 +155,15 @@ describe('Driver', function() {
       assert.ok(machine.streams.bar);
       wireUpPubSub('bar', done);
       machine.incrementStreamValue();
+    });
+
+    it('should create a state stream when transitions are present', function() {
+      assert.ok(machine.streams.state);
+    });
+
+    it('should not create a state stream when no transitions are present', function() {
+      var machine = Scientist.init(Scientist.create(SensorDriver));
+      assert(!machine.streams.state);
     });
   });
 


### PR DESCRIPTION
@mdobson @AdamMagaluk 

Can I get a blessing on this bad boy?  My client code is depending on this working.  This change looks for transitions.  If transitions exist, it must be a state machine.  Therefore, a state stream is auto-wired.  If no transitions exist, no state stream is exposed.
