### PR TITLE
Fix: Monitored property returning null #36

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -151,7 +151,7 @@ Device.prototype.save = function(cb) {
 Device.prototype._initMonitor = function(queueName) {
   var stream = this._createStream(queueName, ObjectStream);
   var self = this;
-  var value = null;
+  var value = this[queueName]; // initialize value
   Object.defineProperty(this, queueName, {
     get: function(){
       return value;

--- a/test/test_driver.js
+++ b/test/test_driver.js
@@ -141,6 +141,8 @@ describe('Driver', function() {
 
     it('should be able to read monitors properties', function() {
       assert.equal(machine.foo, 0);
+      machine.foo = 1;
+      assert.equal(machine.foo, 1);
     });
   });
 


### PR DESCRIPTION
Fixes issue #36, we were not setting the initial value of the monitored property.
