### PR TITLE
When passing arg array should be using .apply not .call

### DIFF
--- a/zetta.js
+++ b/zetta.js
@@ -65,7 +65,7 @@ Zetta.prototype.use = function() {
 
   function init() {
     var instance = Object.create(constructor.prototype);
-    constructor.call(instance, args.slice(1));
+    constructor.apply(instance, args.slice(1));
     return scientist.config(instance);
   }
 


### PR DESCRIPTION
Fixes some issues with the PIR sensor module.
