### PR TITLE
Initialize medea files before adding scouts/devices

### DIFF
--- a/zetta.js
+++ b/zetta.js
@@ -220,6 +220,12 @@ Zetta.prototype._run = function(callback) {
 
   async.series([
     function(next) {
+      self.runtime.registry._init(next);
+    },
+    function(next) {
+      self.peerRegistry._init(next);
+    },
+    function(next) {
       self._initScouts(next);
     },
     function(next) {


### PR DESCRIPTION
Fixes issue with LockFile in medea from init being called twice.