### PR TITLE
zetta package exposes device registry and peer registry files

### DIFF
--- a/zetta_runtime.js
+++ b/zetta_runtime.js
@@ -8,5 +8,7 @@ var exp = function(options) {
 exp.Device = require('zetta-device');
 exp.HttpDevice = require('zetta-http-device');
 exp.Scout = require('zetta-scout');
+exp.DeviceRegistry = require('./lib/device_registry')
+exp.PeerRegistry = require('./lib/peer_registry')
 
 module.exports = exp;


### PR DESCRIPTION
This helps with allowing to create things like we do in `test/fixture/mem_registry.js` when running outside the zetta repo.

ex:

```js
var util = require('util');
var levelup = require('levelup');
var memdown = require('memdown');
var DeviceRegistry = require('../../lib/device_registry');

var MemRegistry = module.exports = function() {
  var db = levelup({ db: memdown });
  DeviceRegistry.call(this, { db: db, collection: 'devices' });
}
util.inherits(MemRegistry, DeviceRegistry);
```
