### PR TITLE
Peering event stream

### DIFF
--- a/lib/api_resources/peer_management.js
+++ b/lib/api_resources/peer_management.js
@@ -296,11 +296,10 @@ PeerManagementBuilder.prototype.actions = function() {
 };
 
 PeerManagementBuilder.prototype.links = function() {
-  this.base.links = [{
-    rel: [rels.self],
-    href: this.urlHelper.current()
-  }];
-
+  this.base.links = [
+    { rel: [rels.self], href: this.urlHelper.current() },
+    { rel: [rels.monitor], href: this.urlHelper.current().replace(/^http/, 'ws') }
+  ];
   return this;
 };
 

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -143,7 +143,7 @@ EventBroker.prototype._publish = function(topic, data) {
     if (!topicMatch(topic, client.query.topic)) {
       return;
     }
-    client.send(data, function(err){
+    client.send(topic, data, function(err){
       if (err) {
         console.error('ws error: '+err);
       }
@@ -168,5 +168,3 @@ EventBroker.prototype.subscribeToDeviceQuery = function(topic) {
     self.zetta.pubsub.publish(topic, { query: topic, device: device });
   });
 };
-
-

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -51,15 +51,14 @@ EventBroker.prototype.client = function(client) {
   this.clients.push(client);
 
   client.on('close', function() {
-    self._unsubscribe(client.query);
+    client.query.forEach(self._unsubscribe.bind(self));
     var idx = self.clients.indexOf(client);
     if (idx === -1) {
       return;
     }
     self.clients.splice(idx, 1);
   });
-
-  this._subscribe(client.query);
+  client.query.forEach(this._subscribe.bind(this));
 };
 
 EventBroker.prototype._subscribe = function(query) {
@@ -140,13 +139,15 @@ EventBroker.prototype._unsubscribe = function(query) {
 
 EventBroker.prototype._publish = function(topic, data) {
   this.clients.forEach(function(client) {
-    if (!topicMatch(topic, client.query.topic)) {
-      return;
-    }
-    client.send(topic, data, function(err){
-      if (err) {
-        console.error('ws error: '+err);
+    client.query.forEach(function(query) {
+      if (!topicMatch(topic, query.topic)) {
+        return;
       }
+      client.send(topic, data, function(err){
+        if (err) {
+          console.error('ws error: '+err);
+        }
+      });
     });
   });
 };

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -7,8 +7,11 @@ var deviceFormatter = require('./api_formats/siren/device.siren');
 var EventSocket = module.exports = function(ws, query) {
   EventEmitter.call(this);
   this.ws = ws;
-  this.query = query; // contains .topic, .name
 
+  if (!Array.isArray(query)) {
+    query = [query];
+  }
+  this.query = query; // contains .topic, .name
   this.init();
 };
 util.inherits(EventSocket, EventEmitter);

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
+var ObjectStream = require('zetta-streams').ObjectStream;
 var buildDeviceActions = require('./api_formats/siren/device.siren').buildActions;
 var deviceFormatter = require('./api_formats/siren/device.siren');
 
@@ -21,9 +22,10 @@ EventSocket.prototype.send = function(topic, data) {
     } else if (data['query']){
       data = deviceFormatter({ loader: this.ws._loader, env: this.ws._env, model: data.device });
     }
-
-    if (typeof data.peer === 'object') {
-      data = data.peer.properites();
+    
+    // used for _peer/connect _peer/disconnect
+    if (Object.keys(data).length === 1 && typeof data.peer === 'object') {
+      data = ObjectStream.format(topic, data.peer.properties());
     }
 
     try {

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -12,33 +12,33 @@ var EventSocket = module.exports = function(ws, query) {
 };
 util.inherits(EventSocket, EventEmitter);
 
-EventSocket.prototype.send = function() {
-  var args = Array.prototype.slice.call(arguments);
-  if (!Buffer.isBuffer(args[0]) && typeof args[0] === 'object') {
-    if (args[0]['transitions']) {
-      var data = args[0];
+EventSocket.prototype.send = function(topic, data) {
+  if (!Buffer.isBuffer(data) && typeof data === 'object') {
+    if (data['transitions']) {
       // format transitions
-      args[0].actions = buildDeviceActions(data.properties.id, this.ws._env, this.ws._loader, data.transitions);
-      delete args[0].transitions;
-    } else if (args[0]['query']){
-      var data = args[0];
-      var formatted = deviceFormatter({ loader: this.ws._loader, env: this.ws._env, model: data.device });
-      args[0] = formatted;
+      data.actions = buildDeviceActions(data.properties.id, this.ws._env, this.ws._loader, data.transitions);
+      delete data.transitions;
+    } else if (data['query']){
+      data = deviceFormatter({ loader: this.ws._loader, env: this.ws._env, model: data.device });
     }
-    
-    var data = null;
+
+    if (typeof data.peer === 'object') {
+      data = data.peer.properites();
+    }
+
     try {
-      data = JSON.stringify(args[0]);
+      data = JSON.stringify(data);
     } catch (err) {
       console.error('ws JSON.stringify ', err);
       return;
     }
-    
-    args[0] = data;
   }
 
+  var args = Array.prototype.slice.call(arguments);
+  args.splice(0, 1); // remove topic
+
   // add callback to args list if it does not have one
-  if (args.length < 3 && typeof args[args.length - 1] !== 'function') {
+  if (args.length < 1 && typeof args[args.length - 1] !== 'function') {
     args.push(function(err) { });
   }
 

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -136,6 +136,13 @@ ZettaHttpServer.prototype.init = function(cb) {
           self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
         });
       }
+    } else if (ws.upgradeReq.url === '/peer_management') {
+      var query = [
+        { name: self.zetta.id, topic: '_peer/connect' },
+        { name: self.zetta.id, topic: '_peer/disconnect' }];
+
+      var client = new EventSocket(ws, query);
+      self.eventBroker.client(client);
     } else {
       self.setupEventSocket(ws);
     }
@@ -220,14 +227,10 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
   query.name = decodeURI(match[1]);
 
   if (query.topic) {
-
-
-
     var qt = querytopic.parse(query.topic);
     if (qt) {
       query.topic = querytopic.format(qt);
     }
-
     var client = new EventSocket(ws, query);
     this.eventBroker.client(client);
   }

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -136,7 +136,7 @@ ZettaHttpServer.prototype.init = function(cb) {
           self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
         });
       }
-    } else if (ws.upgradeReq.url === '/peer_management') {
+    } else if (ws.upgradeReq.url === '/peer-management') {
       var query = [
         { name: self.zetta.id, topic: '_peer/connect' },
         { name: self.zetta.id, topic: '_peer/disconnect' }];

--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -44,6 +44,13 @@ util.inherits(PeerClient, EventEmitter);
 
 PeerClient.calculatePeerUrl = calculatePeerUrl;
 
+PeerClient.prototype.properties = function() {
+  return {
+    url: this.url,
+    connectionId: this.connectionId,
+  };
+};
+
 PeerClient.prototype.start = function() {
   this._createSocket();
 };

--- a/lib/peer_socket.js
+++ b/lib/peer_socket.js
@@ -24,6 +24,13 @@ var PeerSocket = module.exports = function(ws, name, peerRegistry) {
 };
 util.inherits(PeerSocket, EventEmitter);
 
+PeerSocket.prototype.properties = function() {
+  return {
+    id: this.name,
+    connectionId: this.connectionId
+  };
+};
+
 PeerSocket.prototype.close = function() {
   clearInterval(this._pingTimer);
   this.ws.close();

--- a/test/test_event_socket.js
+++ b/test/test_event_socket.js
@@ -19,7 +19,7 @@ describe('EventSocket', function() {
   it('it should initialization with topic set', function() {
     var ws = new Ws();
     var client = new EventSocket(ws, { topic: 'some-topic' });
-    assert.equal(client.query.topic, 'some-topic');
+    assert.equal(client.query[0].topic, 'some-topic');
   });
 
   it('EventSocket.send should pass data/options/callback to ws send', function(done) {

--- a/test/test_event_socket.js
+++ b/test/test_event_socket.js
@@ -34,7 +34,7 @@ describe('EventSocket', function() {
     });
 
     var callback = function() {};
-    client.send('somedata', {opt: 1}, callback);
+    client.send('sometopic', 'somedata', {opt: 1}, callback);
   });
 
   it('websocket error event should trigger close on EventSocket', function(done) {


### PR DESCRIPTION
Allows connecting to `wscat -c http://localhost:5000/peer-management` (cloud) and getting messages like:

```
  < {"topic":"_peer/disconnect","timestamp":1422563336669,"data":{"id":"detroit","connectionId":"9d6c596b-c25d-48d7-9791-5651f811d72a"}}
  < {"topic":"_peer/connect","timestamp":1422563337670,"data":{"id":"detroit","connectionId":"fa36b150-7fc6-4f10-8f41-6129113dc6f8"}}
  < {"topic":"_peer/disconnect","timestamp":1422563338089,"data":{"id":"detroit","connectionId":"fa36b150-7fc6-4f10-8f41-6129113dc6f8"}}
```

Or from the hub side:  `wscat -c ws://localhost:5002/peer-management`

```
connected (press CTRL+C to quit)
  < {"topic":"_peer/disconnect","timestamp":1422563409746,"data":{"url":"ws://localhost:5000/peers/detroit","connectionId":"356c1a66-e5e2-4b9d-91c1-7c2bf73f357b"}}
  < {"topic":"_peer/connect","timestamp":1422563413943,"data":{"url":"ws://localhost:5000/peers/detroit","connectionId":"44f45194-e463-4b2e-8ec2-f4f88cd263e2"}}
```
