### PR TITLE
Includes a hack to allow .use(Device) to only call .init once on the device

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "strftime": "~0.8.0",
     "titan": "~0.1.1",
     "ws": "^0.4.31",
-    "zetta-auto-scout": "^0.6.0",
+    "zetta-auto-scout": "^0.7.0",
     "zetta-device": "^0.9.0",
     "zetta-http-device": "^0.3.0",
     "zetta-rels": "^0.2.0",

--- a/test/test_zetta.js
+++ b/test/test_zetta.js
@@ -237,6 +237,25 @@ describe('Zetta', function() {
       });
   });
 
+  it('should only call .init once on a device driver with .use(Device)', function(done) {
+    var called = 0;
+    var oldInit = ExampleDevice.prototype.init;
+    ExampleDevice.prototype.init = function(config) {
+      called++;
+      return oldInit.call(this, config);
+    };
+
+    var app = zetta({ peerRegistry: peerRegistry, registry: reg });
+    app.silent();
+    app.use(ExampleDevice);
+    app.listen(0);
+    setTimeout(function() {
+      ExampleDevice.prototype.init = oldInit;
+      assert.equal(called, 1);
+      done();
+    }, 10);
+  });
+
   describe('peering', function() {
     it('.link should add to peers', function(done){
       var app = zetta({ peerRegistry: peerRegistry, registry: reg });

--- a/zetta.js
+++ b/zetta.js
@@ -88,19 +88,21 @@ Zetta.prototype.use = function() {
   function init() {
     var instance = Object.create(constructor.prototype);
     constructor.apply(instance, args.slice(1));
-    return scientist.config(instance);
+    return { config: scientist.config(instance), instance: instance };
   }
 
   function walk(proto) {
     if (!proto || !proto.__proto__) {
       self.load(constructor);
     } else if (proto.__proto__.constructor.name === 'HttpDevice') {
-      var instance = init();
-      self.httpScout.driverFunctions[instance._type] = constructor;
+      var config = init().config;
+      self.httpScout.driverFunctions[config._type] = constructor;
     } else if (proto.__proto__.constructor.name === 'Device') {
-      var instance = init();
-      args.unshift(instance._type);
+      var build = init();
+      args.unshift(build.config._type);
       var scout = Object.create(AutoScout.prototype);
+      build.instance._generate(build.config);
+      scout._deviceInstance = build.instance;
       AutoScout.apply(scout, args);
       addScout(scout);
     } else if (proto.__proto__.constructor.name === 'Scout') {


### PR DESCRIPTION
This PR will fail until https://github.com/zettajs/zetta-auto-scout/pull/4 is merged in and pushed to `npm`.