### PR TITLE
Properly emitting error on peer timeouts.

### DIFF
--- a/lib/peer_socket.js
+++ b/lib/peer_socket.js
@@ -104,6 +104,7 @@ PeerSocket.prototype._initWs = function(ws) {
   this.ws = ws;
   this.connectionId = u.query.connectionId;
 
+
   this.ws._socket.removeAllListeners('data'); // Remove WebSocket data handler.
 
   this.ws._socket.on('end', function() {
@@ -142,8 +143,11 @@ PeerSocket.prototype._startPingTimer = function() {
   clearInterval(this._pingTimer);
   this._pingTimer = setInterval(function() {
     var timeout = setTimeout(function() {
-      console.error('PeerSocket PING timeout:', self.name);
+      self.logger.error('PeerSocket', 'PeerSocket timed out for "' + self.name + '".');
       self.close();
+      var err = new Error('Socket timed out');
+      self._setPeerStatus('failed', err);
+      self.emit('error', err);
     }, self._pingTimeout)
 
     self.agent.ping(function(err) {


### PR DESCRIPTION
 Previously peers were getting stuck in the api in certain cases. Fixes #156 