### PR TITLE
websocket no longer emits 'close' event in .close() method but only 'clo...

### DIFF
--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -102,6 +102,9 @@ PeerClient.prototype._createSocket = function() {
       self.ws.on('error', function onError(err) {
         self.connected = false;
         self.log.emit('log', 'peer-client', 'Peer connection error (' + self.url + '): ' + err);
+        if (!self._stopped) {
+          self.close();
+        }
         reconnect(err);
       });
 
@@ -109,10 +112,10 @@ PeerClient.prototype._createSocket = function() {
         //if (self.retryCount > 0) throw new Error('wtf');
         self.connected = false;
         self.log.emit('log', 'peer-client', 'Peer connection closed (' + self.url + '): ' + code + ' - ' + message);
+
         if (!self._stopped) {
           self.close();
         }
-
         reconnect();
       });
     }

--- a/lib/web_socket.js
+++ b/lib/web_socket.js
@@ -32,11 +32,6 @@ var WebSocket = module.exports = function(address, httpOptions) {
   this.setAddress(address);
 
   this.request = revolt();
-
-  var self = this;
-  this.onClose = function() {
-    self.emit('close');
-  };
 };
 
 util.inherits(WebSocket, EventEmitter);
@@ -65,10 +60,9 @@ WebSocket.prototype.close = function() {
   }
 
   this.isClosed = true;
-  this.socket.removeListener('close', this.onClose);
   if(this.socket) {
-    this.socket.end();   
-    this.emit('close', null, null, true);
+    this.socket.end();
+//    this.emit('close', null, null, true);
   } 
 };
 
@@ -99,10 +93,11 @@ WebSocket.prototype.start = function() {
       self.emit('error', 'invalid server key');
       return;
     }
-
+    
+    self.isClosed = false;
     self.socket = env.request.connection;
-    env.request.connection.on('close', function() {
-      self.onClose();
+    self.socket.on('close', function() {
+      self.emit('close');
       env.request.abort();
       subscription.dispose();
     });


### PR DESCRIPTION
...se' event of the underlying socket. Peer client calls the ws.close() method for both ws 'error' and 'close'