### PR TITLE
Updated use to incorporate additonal arguments for an app.

### DIFF
--- a/test/test_zetta.js
+++ b/test/test_zetta.js
@@ -48,24 +48,59 @@ describe('Zetta', function() {
   });
 
 
-  it('will load an app with the load() function', function() {
+  it('will load an app with the load() function', function(done) {
     zetta({ registry: reg, peerRegistry: peerRegistry })
       .silent()
       .load(function(server) {
         assert.ok(server);
         done();
-      });
+      })
+      ._initApps(function(){});
   });
 
-  it('will load an app with the use() function', function() {
+  it('will load an app with the use() function', function(done) {
     zetta({ registry: reg, peerRegistry: peerRegistry })
       .silent()
       .use(function(server) {
         assert.ok(server);
         done();
-      });
+      })
+      ._initApps(function(){});
   });
 
+  it('will load an app with the use() function and additional arguments', function(done) {
+    var app = function(server, opts) {
+      assert.ok(server);
+      assert.ok(opts);
+      assert.equal(opts.foo, 1);
+      done();  
+    }
+    
+    zetta({ registry: reg, peerRegistry: peerRegistry })
+      .silent()
+      .use(app, { foo: 1})
+      ._initApps(function() {
+        
+      });
+
+  });
+
+  it('will load an app with the use() function and additional arguments', function(done) {
+    var app = function(server, foo, bar) {
+      assert.ok(server);
+      assert.equal(foo, 1);
+      assert.equal(bar, 2);
+      done();  
+    }
+    
+    zetta({ registry: reg, peerRegistry: peerRegistry })
+      .silent()
+      .use(app, 1, 2)
+      ._initApps(function() {
+        
+      });
+
+  });
   it('will load a driver with the use() function', function() {
     var z = zetta({ registry: reg, peerRegistry: peerRegistry }).silent();
     function TestDriver() {

--- a/zetta.js
+++ b/zetta.js
@@ -94,7 +94,7 @@ Zetta.prototype.use = function() {
 
   function walk(proto) {
     if (!proto || !proto.__proto__) {
-      self.load(constructor);
+      self.load.apply(self, args);
     } else if (proto.__proto__.constructor.name === 'HttpDevice') {
       var config = init().config;
       self.httpScout.driverFunctions[config._type] = constructor;
@@ -124,7 +124,13 @@ Zetta.prototype.expose = function(query) {
   return this;
 };
 
-Zetta.prototype.load = function(app) {
+Zetta.prototype.load = function() {
+  var args = Array.prototype.slice.call(arguments);
+  var appArgs = args.slice(1, args.length);
+  var app = {
+    app: args[0],
+    args: appArgs
+  };
   this._apps.push(app);
   return this;
 };
@@ -267,7 +273,9 @@ Zetta.prototype._initScouts = function(callback) {
 Zetta.prototype._initApps = function(callback) {
   var self = this;
   this._apps.forEach(function(app) {
-    app(self.runtime);
+    var args = app.args;
+    args.unshift(self.runtime);
+    app.app.apply(null, args);
   });
   callback();
 


### PR DESCRIPTION
Accounting for adding extra arguments to an app. This use case now works.

```
var app = function(server, foo, bar) {}

var z = require('zetta');
z()
  .use(app, 1, 2)
  .listen(0);
```