### PR TITLE
Fix peer event subscriptions

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -112,7 +112,6 @@ ZettaHttpServer.prototype.init = function(cb) {
         peer.init(ws);
       } else {
         peer = new PeerSocket(ws, name, self.peerRegistry);
-
         peer.on('connected', function() {
           self.peers[name] = peer;
           self.eventBroker.peer(peer);
@@ -122,17 +121,25 @@ ZettaHttpServer.prototype.init = function(cb) {
         });
 
         peer.on('error', function(err) {
-          self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
-          self._disconnectedPeers[name] = self.peers[name];
-          delete self.peers[name];
-          self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+          // guard against multiple 'error' or 'end' events per 'connected' event
+          if (self.peers[name]) {
+            self._disconnectedPeers[name] = self.peers[name];
+            delete self.peers[name];
+            
+            self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
+            self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+          }
         });
 
         peer.on('end', function() {
-          self._disconnectedPeers[name] = self.peers[name];
-          delete self.peers[name];
-          self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
-          self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+          // guard against multiple 'error' or 'end' events per 'connected' event
+          if (self.peers[name]) {
+            self._disconnectedPeers[name] = self.peers[name];
+            delete self.peers[name];
+            
+            self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
+            self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+          }
         });
       }
     } else if (ws.upgradeReq.url === '/peer-management') {

--- a/test/test_peer_connection.js
+++ b/test/test_peer_connection.js
@@ -129,4 +129,53 @@ describe('Peer Connection Logic', function() {
     });
   })
 
+  describe('Peer_socket error events', function() {
+
+    it('http-server should handle multiple error events', function(done) {
+      var z = zetta({ registry: new MemRegistry(), peerRegistry: new MemPeerRegistry() })
+        .name('test-peer')
+        .silent()
+        .link(cloudUrl)
+        .listen(0);
+
+      cloud.pubsub.subscribe('_peer/connect', function(topic, data) {
+        assert(cloud.httpServer.peers['test-peer']);
+        var peer = cloud.httpServer.peers['test-peer'];
+
+        cloud.pubsub.subscribe('_peer/disconnect', function(topic, data) {
+          assert(cloud.httpServer.peers['test-peer'] === undefined);
+          assert(cloud.httpServer._disconnectedPeers['test-peer']);
+        });
+
+        peer.emit('error', new Error('some error'));
+        peer.emit('error', new Error('some error'));
+        done();
+      })
+    });
+
+
+    it('http-server should handle multiple end events', function(done) {
+      var z = zetta({ registry: new MemRegistry(), peerRegistry: new MemPeerRegistry() })
+        .name('test-peer')
+        .silent()
+        .link(cloudUrl)
+        .listen(0);
+
+      cloud.pubsub.subscribe('_peer/connect', function(topic, data) {
+        assert(cloud.httpServer.peers['test-peer']);
+        var peer = cloud.httpServer.peers['test-peer'];
+
+        cloud.pubsub.subscribe('_peer/disconnect', function(topic, data) {
+          assert(cloud.httpServer.peers['test-peer'] === undefined);
+          assert(cloud.httpServer._disconnectedPeers['test-peer']);
+        });
+
+        peer.emit('end');
+        peer.emit('end');
+        done();
+      })
+    });
+
+  });
+
 })


### PR DESCRIPTION
There is a bug in the peer connection where if a peer_socket emits an `error` or `end` event multiple times per one `connected` event it causes an issue with http_server managing the connected peers.

Only way i was able to get the peer_socket to emit multiple `error` events was to have a peer connect to my laptop then disconnect the wifi. There will be an `error` event emitted from the ping timer code that says its connection timed out. But there is another event being thrown from somewhere else.