### PR TITLE
Peer socket connection issue

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -28,7 +28,6 @@ var ZettaHttpServer = module.exports = function(zettaInstance) {
   this.eventBroker = new EventBroker(zettaInstance);
   this.clients = {};
   this.peers = {}; // connected peers
-  this._disconnectedPeers = {};
 
   this._deviceQueries = [];
 
@@ -101,45 +100,30 @@ ZettaHttpServer.prototype.init = function(cb) {
       name = decodeURI(name);
       self.zetta.log.emit('log', 'http_server', 'Websocket connection for peer "' + name + '" established.');
 
-      var peer = null;
-      if (self.peers[name]) {
-        // peer already connected?
+      if (self.peers[name] && self.peers[name].state !== PeerSocket.DISCONNECTED) {
+        // peer already connected or connecting
         ws.close(4000, 'peer already connected');
-      } else if (self._disconnectedPeers[name]) {
+      } else if (self.peers[name]) {
         // peer has been disconnected but has connected before.
-        peer = self._disconnectedPeers[name];
-        delete self._disconnectedPeers[name];
-        peer.init(ws);
+        self.peers[name].init(ws);
       } else {
-        peer = new PeerSocket(ws, name, self.peerRegistry);
-        peer.on('connected', function() {
-          self.peers[name] = peer;
-          self.eventBroker.peer(peer);
+        var peer = new PeerSocket(ws, name, self.peerRegistry);
+        self.peers[name] = peer;
 
+        peer.on('connected', function() {
+          self.eventBroker.peer(peer);
           self.zetta.log.emit('log', 'http_server', 'Peer connection established "' + name + '".');
           self.zetta.pubsub.publish('_peer/connect', { peer: peer });
         });
 
         peer.on('error', function(err) {
-          // guard against multiple 'error' or 'end' events per 'connected' event
-          if (self.peers[name]) {
-            self._disconnectedPeers[name] = self.peers[name];
-            delete self.peers[name];
-            
-            self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
-            self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
-          }
+          self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
+          self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
         });
 
         peer.on('end', function() {
-          // guard against multiple 'error' or 'end' events per 'connected' event
-          if (self.peers[name]) {
-            self._disconnectedPeers[name] = self.peers[name];
-            delete self.peers[name];
-            
-            self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
-            self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
-          }
+          self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
+          self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
         });
       }
     } else if (ws.upgradeReq.url === '/peer-management') {

--- a/lib/peer_socket.js
+++ b/lib/peer_socket.js
@@ -8,9 +8,17 @@ var ws = require('ws');
 var SpdyAgent = require('./spdy_agent');
 var Logger = require('./logger');
 
+var STATES = {
+  'DISCONNECTED' : 0,
+  'CONNECTING': 1,
+  'CONNECTED': 2
+};
+
 var PeerSocket = module.exports = function(ws, name, peerRegistry) {
   EventEmitter.call(this);
 
+  var self = this;
+  this.state = STATES.DISCONNECTED;
   this.name = name; // peers local id
   this.agent = null;
   this.subscriptions = {}; // { <topic>: <subscribed_count> }
@@ -20,9 +28,32 @@ var PeerSocket = module.exports = function(ws, name, peerRegistry) {
   this.peerRegistry = peerRegistry;
   this.logger = new Logger();
   
+  this.on('connecting', function() {
+    self.state = STATES.CONNECTING;    
+  });
+
+  this.on('end', function() {
+    self.state = STATES.DISCONNECTED;
+    self._setRegistryStatus('disconnected');
+  });
+
+  this.on('error', function(err) {
+    self.state = STATES.DISCONNECTED;
+    self._setRegistryStatus('failed', err);
+  });
+
+  this.on('connected', function() {
+    self.state = STATES.CONNECTED;
+    self._setRegistryStatus('connected');
+  });
+  
   this.init(ws);
 };
 util.inherits(PeerSocket, EventEmitter);
+
+Object.keys(STATES).forEach(function(k) {
+  module.exports[k] = STATES[k];
+});
 
 PeerSocket.prototype.properties = function() {
   return {
@@ -38,6 +69,7 @@ PeerSocket.prototype.close = function() {
 
 PeerSocket.prototype.init = function(ws) {
   var self = this;
+  self.emit('connecting');
   
   if (ws) {
     this._initWs(ws);
@@ -49,15 +81,14 @@ PeerSocket.prototype.init = function(ws) {
     self._setupConnection(function(err) {
       if (err) {
         self.close();
+        self.emit('error', err);
         return;
       }
 
-
-
       if (self.ws.readyState !== ws.OPEN) {
-        self.logger.emit('log', 'peer_socket', 'Peer Socket: Setup connection finished but ws not opened for peer "' + self.name + '".');
         // dissconnected already, reset
         self.close();
+        self.emit('error', new Error('Peer Socket: Setup connection finished but ws not opened for peer "' + self.name + '".'));
         return;
       }
 
@@ -88,13 +119,7 @@ PeerSocket.prototype._setupConnection = function(cb, tries) {
     }
 
     // confirm connection with peer
-    self.confirmConnection(self.connectionId, function(err) {
-      if (err) {
-        return cb(new Error('Failed to confirm connection.'));
-      }
-      self._setPeerStatus('connected', cb);
-    });
-
+    self.confirmConnection(self.connectionId, cb);
   });
 };
 
@@ -109,13 +134,11 @@ PeerSocket.prototype._initWs = function(ws) {
 
   this.ws._socket.on('end', function() {
     clearInterval(self._pingTimer);
-    self._setPeerStatus('disconnected');
     self.emit('end');
   });
 
   this.ws.on('error', function(err) {
     clearInterval(self._pingTimer);
-    self._setPeerStatus('failed', err);
     self.emit('error', err);
   });
 
@@ -143,11 +166,8 @@ PeerSocket.prototype._startPingTimer = function() {
   clearInterval(this._pingTimer);
   this._pingTimer = setInterval(function() {
     var timeout = setTimeout(function() {
-      self.logger.error('PeerSocket', 'PeerSocket timed out for "' + self.name + '".');
       self.close();
-      var err = new Error('Socket timed out');
-      self._setPeerStatus('failed', err);
-      self.emit('error', err);
+      self.emit('error', new Error('Peer socket timed out'));
     }, self._pingTimeout)
 
     self.agent.ping(function(err) {
@@ -159,18 +179,13 @@ PeerSocket.prototype._startPingTimer = function() {
 
 };
 
-PeerSocket.prototype._setPeerStatus = function(status, err, cb) {
+PeerSocket.prototype._setRegistryStatus = function(status, err, cb) {
   var self = this;
   
-
-  // set internal state
-  this.status = status;
-
   if (typeof err === 'function') {
     cb = err;
     err = undefined;
   }
-
 
   if (!cb) {
     cb = function(){};

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -120,7 +120,7 @@ Runtime.prototype.observe = function(queries, cb) {
       }
 
       // handle case of query.server = '*'
-      var peer = self.httpServer.peers[query.server] || self.httpServer._disconnectedPeers[query.server];
+      var peer = self.httpServer.peers[query.server];
 
       var queryObservable = Rx.Observable.create(function(observer) {
 

--- a/test/test_peer_connection.js
+++ b/test/test_peer_connection.js
@@ -31,7 +31,7 @@ describe('Peer Connection Logic', function() {
       if (err) {
         return done(err);
       }
-      
+
       cloudUrl = 'ws://localhost:' + cloud.httpServer.server.address().port;
       done();
     })
@@ -48,7 +48,7 @@ describe('Peer Connection Logic', function() {
         .silent()
         .link(cloudUrl)
         .listen(0);
-      
+
       z.pubsub.subscribe('_peer/connect', function(topic, data) {
         if (data.peer.url.indexOf(cloudUrl) === 0) {
           done();
@@ -64,7 +64,7 @@ describe('Peer Connection Logic', function() {
         .listen(0, function() {
           z.link(cloudUrl);
         });
-      
+
       z.pubsub.subscribe('_peer/connect', function(topic, data) {
         if (data.peer.url.indexOf(cloudUrl) === 0) {
           done();
@@ -144,8 +144,7 @@ describe('Peer Connection Logic', function() {
         var peer = cloud.httpServer.peers['test-peer'];
 
         cloud.pubsub.subscribe('_peer/disconnect', function(topic, data) {
-          assert(cloud.httpServer.peers['test-peer'] === undefined);
-          assert(cloud.httpServer._disconnectedPeers['test-peer']);
+          assert.equal(cloud.httpServer.peers['test-peer'].state, PeerSocket.DISCONNECTED);
         });
 
         peer.emit('error', new Error('some error'));
@@ -167,8 +166,7 @@ describe('Peer Connection Logic', function() {
         var peer = cloud.httpServer.peers['test-peer'];
 
         cloud.pubsub.subscribe('_peer/disconnect', function(topic, data) {
-          assert(cloud.httpServer.peers['test-peer'] === undefined);
-          assert(cloud.httpServer._disconnectedPeers['test-peer']);
+          assert.equal(cloud.httpServer.peers['test-peer'].state, PeerSocket.DISCONNECTED);
         });
 
         peer.emit('end');
@@ -226,7 +224,7 @@ describe('Peer Connection Logic', function() {
         if (count === 1) {
           lastPeer = data.peer;
           cloud.httpServer.peers['peer-1'].close();
-          
+
           client.once('connecting', function() {
             var origRequest = client.onRequest;
             client.server.removeListener('request', client.onRequest);

--- a/test/test_peer_connection.js
+++ b/test/test_peer_connection.js
@@ -124,9 +124,11 @@ describe('Peer Connection Logic', function() {
       var ws = new Ws();
       var socket = new PeerSocket(ws, 'some-peer', new MemPeerRegistry);
       socket.on('error', function(err) {
-        done();
+        if (err.message === 'spdy-error') {
+          done();
+        }
       });
-      socket.agent.emit('error', new Error(''));
+      socket.agent.emit('error', new Error('spdy-error'));
     });
   })
 


### PR DESCRIPTION
 - Changes the internals of http_server and peer_socket to remove http_server from having to keep track of a list of connected vs disconnected peers. It was causing an issue when a peer disconnects before the peer connection was fully established then next time the peer connected it would not re-subscribe to any event topics.