### PR TITLE
Cross-server query support.

### DIFF
--- a/lib/api_resources/root.js
+++ b/lib/api_resources/root.js
@@ -49,12 +49,12 @@ RootResource.prototype.list = function(env, next) {
           var messageId;
 
           var entities = results.map(function(obj) {
-            var response = obj.res;
-            var body = obj.body;
-
             if (obj.err) {
               return [];
             }
+
+            var response = obj.res;
+            var body = obj.body;
 
             var id = response.headers['zetta-message-id'];
 

--- a/lib/api_resources/root.js
+++ b/lib/api_resources/root.js
@@ -2,6 +2,7 @@ var rels = require('zetta-rels');
 var MediaType = require('api-media-type');
 var querystring = require('querystring');
 var Query = require('calypso').Query;
+var rel = require('zetta-rels');
 
 var RootResource = module.exports = function(server) {
   this.server = server;
@@ -27,29 +28,119 @@ RootResource.prototype.proxy = function(env, next) {
 RootResource.prototype.list = function(env, next) {
   var self = this;
   var params = env.route.query;
-  if(params.ql) {
+  if (params.ql) {
     var ql = params.ql;
     var server = params.server || this.server.id;
 
-    if(this.shouldProxy(server)) {
+    if (server === '*') {
+      this.server.peerRegistry.find(Query.of('peers'), function(err, peers) {
+        if (err) {
+          env.response.statusCode = 500;
+          return next(env);
+        }
+
+        var href = '/servers/{{peerName}}';
+        var qs ='?' + querystring.stringify({ql: params.ql});
+        env.request.templateUrl = href + qs;
+
+        var httpServer = self.server.httpServer;
+
+        httpServer.proxyToPeers(peers, env, function(err, results) {
+          var messageId;
+
+          var entities = results.map(function(obj) {
+            var response = obj.res;
+            var body = obj.body;
+
+            if (obj.err) {
+              return [];
+            }
+
+            var id = response.headers['zetta-message-id'];
+
+            if (!messageId) {
+              messageId = id;
+            }
+
+            var res = httpServer.clients[id];
+
+            if (!res) {
+              return [];
+            }
+
+            Object.keys(response.headers).forEach(function(header) {
+              if (header !== 'zetta-message-id') {
+                res.setHeader(header, response.headers[header]);
+              }
+            });
+
+            res.statusCode = response.statusCode;
+
+            if (body) {
+              body = JSON.parse(body.toString());
+              return body && body.entities ? body.entities : [];
+            } else {
+              return [];
+            }
+          }).reduce(function(prev, curr) {
+            return prev.concat(curr);
+          }, []);
+
+          self.server.runtime.registry.find(params.ql, function(err, results) {
+            var localEntities = (!!err || !results) ? [] : results.map(function(device){
+              var deviceOnRuntime = self.server.runtime._jsDevices[device.id];
+              if (deviceOnRuntime) {
+                var model = deviceOnRuntime;
+                var loader = {path: '/servers/' + encodeURI(self.server.id)}
+                var server = self.server;
+                var entity = {
+                  class: ['device'],
+                  rel: [rel.device],
+                  properties: model.properties(),
+                  links: [{ rel: ['self'], href: env.helpers.url.path(loader.path + '/devices/' + model.id) },
+                          { title: server._name, rel: ['up', rel.server], href: env.helpers.url.path(loader.path) }]
+                };
+                return entity;
+              }
+            }).filter(function(entity) { return entity !== null });
+
+            var res = httpServer.clients[messageId];
+            var obj = {
+              class: ['root', 'search-results'],
+              properties: {
+                ql: params.ql
+              },
+              entities: localEntities.concat(entities),
+              links: [
+                { rel: ['self'], href: env.helpers.url.current() },
+                { rel: [rel.query], href: '' }
+              ]
+            }
+
+            var queryTopic = querystring.stringify({topic: 'query/'+params.ql, since: new Date().getTime()});
+            obj.links.push({ rel: [rel.query], href: env.helpers.url.path('/events').replace(/^http/, 'ws') + '?' + queryTopic });
+
+            res.body = JSON.stringify(obj);
+            delete httpServer.clients[messageId];
+            next(env);
+          });
+        });
+      });
+    } else if (this.shouldProxy(server)) {
       this.server.peerRegistry.get(server, function(err, peer) {
         if(err) {
           env.response.statusCode = 500;
           return next(env);
-        } else {
-          var href = '/servers/' + encodeURI(peer.id);
-          var qs ='?' + querystring.stringify({ql: params.ql});
-          env.request.url = href + qs;
-          self.proxy(env, next);
         }
-      });
 
+        var href = '/servers/' + encodeURI(peer.id);
+        var qs ='?' + querystring.stringify({ql: params.ql});
+        env.request.url = href + qs;
+        self.proxy(env, next);
+      });
     } else {
       this._queryDevices(env, next);
     }
-    //check server id
-    //proxy if not the same
-    //send response back
   } else {
     this._renderRoot(env, next);
   }

--- a/lib/api_resources/root.js
+++ b/lib/api_resources/root.js
@@ -45,9 +45,7 @@ RootResource.prototype.list = function(env, next) {
 
         var httpServer = self.server.httpServer;
 
-        httpServer.proxyToPeers(peers, env, function(err, results) {
-          var messageId;
-
+        httpServer.proxyToPeers(peers, env, function(err, results, messageId) {
           var entities = results.map(function(obj) {
             if (obj.err) {
               return [];

--- a/lib/api_resources/root.js
+++ b/lib/api_resources/root.js
@@ -108,12 +108,12 @@ RootResource.prototype.list = function(env, next) {
             var obj = {
               class: ['root', 'search-results'],
               properties: {
+                server: '*',
                 ql: params.ql
               },
               entities: localEntities.concat(entities),
               links: [
-                { rel: ['self'], href: env.helpers.url.current() },
-                { rel: [rel.query], href: '' }
+                { rel: ['self'], href: env.helpers.url.current() }
               ]
             }
 

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -47,7 +47,33 @@ EventBroker.prototype._setupPublishListener = function(peer, topic) {
 
 EventBroker.prototype.client = function(client) {
   var self = this;
-  //client.topic
+  var c = this.clients.filter(function(cl) {
+    if (client.query.length !== cl.query.length) {
+      return null;
+    }
+
+    var stillValid = true;
+    for (var i = 0; i < client.query.length; i++) {
+      if (!cl.query[i]) {
+        stillValid = false;
+        break;
+      }
+
+      var clq = querytopic.parse(cl.query[i].topic);
+      var clientq = querytopic.parse(client.query[i].topic);
+
+      if ((!clq || !clientq) || clq.ql !== clientq.ql || cl.query[i].name !== client.query[i].name) {
+        stillValid = false;
+      }
+    }
+
+    return stillValid && client.ws === cl.ws;
+  });
+
+  if (c.length > 0) {
+    return;
+  }
+
   this.clients.push(client);
 
   client.on('close', function() {

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -111,6 +111,11 @@ EventBroker.prototype._unsubscribe = function(query) {
     // unsubscribe locally
     this.zetta.pubsub.unsubscribe(topic, this.subscriptions[topic].listener);
     delete this.subscriptions[topic];
+
+    if (this._deviceQueries[topic]) {
+      this._deviceQueries[topic].dispose();
+      delete this._deviceQueries[topic];
+    }
   } else {
     if (!this._peerSubscriptions[query.name]) {
       this._peerSubscriptions[query.name] = { topic: 1};
@@ -148,6 +153,7 @@ EventBroker.prototype._publish = function(topic, data) {
       if (!topicMatch(topic, query.topic)) {
         return;
       }
+
       client.send(topic, data, function(err){
         if (err) {
           console.error('ws error: '+err);

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -347,7 +347,7 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
   });
 
   async.parallelLimit(tasks, 5, function(err, results) {
-    cb(err, results);
+    cb(err, results, messageId);
   });
 };
 

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -2,6 +2,7 @@ var http = require('http');
 var path = require('path');
 var url = require('url');
 var querystring = require('querystring');
+var async = require('async');
 var spdy = require('spdy');
 var argo = require('argo');
 var titan = require('titan');
@@ -162,22 +163,9 @@ ZettaHttpServer.prototype.collector = function(name, collector) {
   return this;
 };
 
-ZettaHttpServer.prototype.setupEventSocket = function(ws) {
-  var self = this;
-
-  var match = /^\/servers\/(.+)\/events/.exec(ws.upgradeReq.url);
-  if(!match) {
-    ws.close(1001); // go away status code
-    return;
-  }
-
-  var query = querystring.parse(url.parse(ws.upgradeReq.url).query);
-  query.serverId = match[1]; // set serverId on query
-
-  // setup helpers for
+ZettaHttpServer.prototype.wireUpWebSocketForEvent = function(ws, host, p) {
   ws._env = { helpers: {}};
-  var serverId = query.serverId;
-  ws._loader = { path: '/servers/' + serverId };
+  ws._loader = { path: p };
 
   ws._env.uri = function() {
     var xfp = ws.upgradeReq.headers['x-forwarded-proto'];
@@ -188,8 +176,6 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
     } else {
       protocol = ws.upgradeReq.connection.encrypted ? 'https' : 'http';
     }
-
-    var host = ws.upgradeReq.headers['host'];
 
     if (!host) {
       var address = ws.upgradeReq.connection.address();
@@ -203,7 +189,7 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
     }
 
     return protocol + '://' + path.join(host, ws.upgradeReq.url);
-  }
+  };
 
   ws._env.helpers.url = {};
   ws._env.helpers.url.path = function(pathname) {
@@ -212,17 +198,76 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
     parsed.pathname = pathname;
     return url.format(parsed);
   };
+};
 
-  var query = querystring.parse(url.parse(ws.upgradeReq.url).query);
-  query.name = decodeURI(match[1]);
+ZettaHttpServer.prototype.setupEventSocket = function(ws) {
+  var self = this;
+  var host = ws.upgradeReq.headers['host'];
 
-  if (query.topic) {
-    var qt = querytopic.parse(query.topic);
-    if (qt) {
-      query.topic = querytopic.format(qt);
+  if (/^\/events/.exec(ws.upgradeReq.url)) {
+    self.wireUpWebSocketForEvent(ws, host, '/servers/' + self.zetta._name);
+
+    var query = querystring.parse(url.parse(ws.upgradeReq.url).query);
+
+    function copy(q) {
+      var c = {};
+      Object.keys(q).forEach(function(k) {
+        c[k] = q[k];
+      });
+
+      return c;
     }
-    var client = new EventSocket(ws, query);
-    this.eventBroker.client(client);
+
+    [self.zetta._name].concat(Object.keys(self.peers)).forEach(function(serverId) {
+      var q = copy(query);
+      q.name = serverId;
+
+      if (q.topic) {
+        var qt = querytopic.parse(query.topic);
+        if (qt) {
+          q.topic = querytopic.format(qt);
+        }
+        var client = new EventSocket(ws, q);
+        self.eventBroker.client(client);
+      }
+    });
+
+    self.zetta.pubsub.subscribe('_peer/connect', function(e, obj) {
+      var q = copy(query);
+      q.name = obj.peer.name;
+
+      if (q.topic) {
+        var qt = querytopic.parse(query.topic);
+        if (qt) {
+          q.topic = querytopic.format(qt);
+        }
+        var client = new EventSocket(ws, q);
+        self.eventBroker.client(client);
+      }
+    });
+  } else {
+    var match = /^\/servers\/(.+)\/events/.exec(ws.upgradeReq.url);
+    if(!match) {
+      ws.close(1001); // go away status code
+      return;
+    }
+
+    var query = querystring.parse(url.parse(ws.upgradeReq.url).query);
+    query.serverId = match[1]; // set serverId on query
+
+    self.wireUpWebSocketForEvent(ws, host, '/servers/' + query.serverId);
+
+    var query = querystring.parse(url.parse(ws.upgradeReq.url).query);
+    query.name = decodeURI(match[1]);
+
+    if (query.topic) {
+      var qt = querytopic.parse(query.topic);
+      if (qt) {
+        query.topic = querytopic.format(qt);
+      }
+      var client = new EventSocket(ws, query);
+      self.eventBroker.client(client);
+    }
   }
 };
 
@@ -248,7 +293,57 @@ ZettaHttpServer.prototype.httpRegistration = function(handle) {
   });
 };
 
-//ZettaHttpServer.prototype.proxyToPeer = function(handle) {
+ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
+  var self = this;
+
+  var req = env.request;
+  var res = env.response;
+
+  var messageId = ++self.idCounter;
+  self.clients[messageId] = res;
+
+  var tasks = peers.map(function(p) {
+    var name = p.id;
+    return function(callback) {
+
+      var reqUrl = req.templateUrl.replace('{{peerName}}', encodeURIComponent(name));
+      var headers = {};
+
+      Object.keys(req.headers).forEach(function(key) {
+        headers[key] = req.headers[key];
+      });
+
+      headers['zetta-message-id'] = messageId;
+      headers['zetta-forwarded-server'] = name;
+
+      var peer = self.peers[name];
+      if (!peer){
+        cb(null, []);
+        return;
+      }
+
+      var agent = env.zettaAgent || peer.agent;
+
+      var opts = { method: req.method, headers: headers, path: reqUrl, agent: agent };
+      var request = http.request(opts, function(response) {
+        response.getBody(function(err, body) {
+          callback(null, { res: response, err: err, body: body });
+        });
+      });
+
+      if (req.body) {
+        request.end(req.body);
+      } else {
+        req.pipe(request);
+      }
+    };
+  });
+
+  async.parallelLimit(tasks, 5, function(err, results) {
+    cb(err, results);
+  });
+};
+
 ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
   var self = this;
 

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -318,7 +318,7 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
 
       var peer = self.peers[name];
       if (!peer){
-        cb(null, []);
+        callback(null, { err: new Error('Peer does not exist.') });
         return;
       }
 

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -232,7 +232,7 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
       }
     });
 
-    self.zetta.pubsub.subscribe('_peer/connect', function(e, obj) {
+    function subscribeOnPeerConnect(e, obj) {
       var q = copy(query);
       q.name = obj.peer.name;
 
@@ -241,10 +241,17 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
         if (qt) {
           q.topic = querytopic.format(qt);
         }
+
         var client = new EventSocket(ws, q);
         self.eventBroker.client(client);
       }
+    }
+
+    ws.on('close', function() {
+      self.zetta.pubsub.unsubscribe('_peer/connect', subscribeOnPeerConnect);
     });
+
+    self.zetta.pubsub.subscribe('_peer/connect', subscribeOnPeerConnect);
   } else {
     var match = /^\/servers\/(.+)\/events/.exec(ws.upgradeReq.url);
     if(!match) {
@@ -317,7 +324,7 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
       headers['zetta-forwarded-server'] = name;
 
       var peer = self.peers[name];
-      if (!peer){
+      if (!peer || peer.state !== PeerSocket.CONNECTED){
         callback(null, { err: new Error('Peer does not exist.') });
         return;
       }

--- a/lib/query_topic.js
+++ b/lib/query_topic.js
@@ -24,10 +24,12 @@ module.exports.parse = function parseDeviceQuery(q) {
   }
 
   var split = q.split('/');
-  return {
+  var ret = {
     id: (split.splice(0, 1)[0].split(':')[1] || uuid.v4() ),
     ql: split.join('/')
   };
+
+  return ret;
 };
 
 module.exports.format = function formatDeviceQuery(obj) {

--- a/test/test_query_api.js
+++ b/test/test_query_api.js
@@ -245,6 +245,38 @@ describe('Zetta Query Api', function() {
         .end(done);
     });
   });
+
+  describe('queries on / for all peers', function() {
+    var app = null;
+    var cluster = null;
+
+    beforeEach(function(done) {
+      cluster = zettacluster({ zetta: zetta })
+        .server('cloud')
+        .server('detroit1', [Scout], ['cloud'])
+        .server('detroit2', [Scout], ['cloud'])
+        .on('ready', function() {
+          app = cluster.servers['cloud'];
+          done();
+        })
+        .run(function(err){
+          if (err) {
+            return done(err);
+          }
+        });
+    });
+
+    it('should return results from each server', function(done) {
+      request(getHttpServer(app))
+        .get('/?ql=where%20type%20=%20"testdriver"&server=*')
+        .expect(getBody(function(res, body) {
+          assert.equal(body.entities.length, 2);
+          hasLinkRel(body.links, 'http://rels.zettajs.io/query');
+        }))
+        .end(done);
+
+    });
+  });
  
   describe('queries on /servers/<id>', function() {
     var app = null;

--- a/test/test_remote_query.js
+++ b/test/test_remote_query.js
@@ -225,10 +225,8 @@ describe('Remote queries', function() {
           assert.equal(json.properties.type, 'testdriver');
           socket.close();
 
-          console.log(urlLocal);
           var socket2 = new WebSocket("ws://" + urlLocal + '/events?topic=query/where type = "testdriver"');
           socket2.on('open', function(err) {
-            console.log('open');
             socket2.on('message', function(data) {
               var json = JSON.parse(data);
               assert.equal(json.properties.type, 'testdriver');

--- a/test/test_remote_query.js
+++ b/test/test_remote_query.js
@@ -225,8 +225,10 @@ describe('Remote queries', function() {
           assert.equal(json.properties.type, 'testdriver');
           socket.close();
 
+          console.log(urlLocal);
           var socket2 = new WebSocket("ws://" + urlLocal + '/events?topic=query/where type = "testdriver"');
           socket2.on('open', function(err) {
+            console.log('open');
             socket2.on('message', function(data) {
               var json = JSON.parse(data);
               assert.equal(json.properties.type, 'testdriver');


### PR DESCRIPTION
Fixes #176.

Fixing URL in root-level search results self link.

Adding some more protection around body parsing for root level queries.

Returning local results in addition to peer results when querying across servers.

Wiring up reactive WebSocket for cross-server queries.

Subscribing to new peers on cross-server query.

Fixing issue with duplicate events.

Adding another check for cross-server query test.

Cleaning up observable after query subscription is removed.

Removing stray console.log

Reverting ID change to name on cross-server query clients.