### PR TITLE
Added support to query .from('*') in zetta app.

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -119,12 +119,10 @@ Runtime.prototype.observe = function(queries, cb) {
         ql = ql.slice(toRemove.length);
       }
 
-      // handle case of query.server = '*'
-      var peer = self.httpServer.peers[query.server];
-
       var queryObservable = Rx.Observable.create(function(observer) {
 
-        if (!peer) {
+        // peer not connected or query is for all peers
+        if (!self.httpServer.peers[query.server] || query.server === '*') {
           // init peer on connect / reconnect
           self.pubsub.subscribe('_peer/connect', function(ev, data) {
             if (data.peer.name === query.server) {
@@ -133,7 +131,14 @@ Runtime.prototype.observe = function(queries, cb) {
               self._initRemoteQueryListener(ql, data.peer);
             }
           });
-        } else {
+        }
+
+        function setupForPeer(peerName) {
+          var peer = self.httpServer.peers[peerName];
+          if (!peer) {
+            return;
+          }
+
           // iterate through existing remote devices
           if (self._remoteDevices[peer.name]) {
             Object.keys(self._remoteDevices[peer.name]).forEach(function(deviceId) {
@@ -158,17 +163,34 @@ Runtime.prototype.observe = function(queries, cb) {
           }
 
           self._initRemoteQueryListener(ql, peer);
+
+          // listen for devices comming online from remote per observer
+          self.on(peer.name + '/remotedeviceready', function(device) {
+            self.registry.match(query, device, function(err, match) {
+              if (match) {
+                observer.onNext(device);
+              }
+            });
+          });
         }
 
-        // listen for devices comming online from remote per observer
-        self.on(query.server + '/remotedeviceready', function(device) {
-          self.registry.match(query, device, function(err, match) {
-            if (match) {
-              observer.onNext(device);
-            }
+        if (query.server === '*') {
+          var peersSetup = [];
+          Object.keys(self.httpServer.peers).forEach(function(peerName) {
+            peersSetup.push(peerName);
+            setupForPeer(peerName);
           });
-        });
-
+          
+          // setup all future peers
+          self.pubsub.subscribe('_peer/connect', function(e, data) {
+            if (peersSetup.indexOf(data.peer.name) === -1) {
+              peersSetup.push(data.peer.name);
+              setupForPeer(data.peer.name);
+            }
+          })
+        } else {
+          setupForPeer(query.server);
+        }
       });
 
       filters.push(queryObservable);

--- a/test/test_remote_query.js
+++ b/test/test_remote_query.js
@@ -10,6 +10,8 @@ var decompiler = require('calypso-query-decompiler');
 var ZScout = require('zetta-scout');
 var util = require('util');
 var WebSocket = require('ws');
+var MemRegistry = require('./fixture/mem_registry');
+var MemPeerRegistry = require('./fixture/mem_peer_registry');
 
 
 function FakeScout() {
@@ -33,6 +35,7 @@ var mockSocket = {
 describe('Remote queries', function() {
   var cluster = null;
   var detroit1 = null;
+  var chicago = null;
   var cloud = null;
   var urlLocal = null;
   var urlProxied = null
@@ -42,12 +45,14 @@ describe('Remote queries', function() {
     cluster = zettacluster({ zetta: zetta })
       .server('cloud', [Scout])
       .server('detroit1', [Scout], ['cloud'])
+      .server('chicago', [Scout], ['cloud'])
       .on('ready', function() {
         urlRoot = 'localhost:' + cluster.servers['cloud']._testPort;
         urlProxied = 'localhost:' + cluster.servers['cloud']._testPort + '/servers/detroit1';
         urlLocal = 'localhost:' + cluster.servers['detroit1']._testPort + '/servers/detroit1';
 
         detroit1 = cluster.servers['detroit1'];
+        chicago = cluster.servers['chicago'];
         cloud = cluster.servers['cloud'];
         done();
       })
@@ -73,6 +78,54 @@ describe('Remote queries', function() {
       detroit1.pubsub.subscribe(key, function() {
         done();
       });
+    });
+
+
+    it('should return all test devices when quering .from(\'*\')', function(done) {
+      var query = cloud.runtime.from('*').where({type: 'testdriver'});
+      var count = 0;
+      cloud.runtime.observe(query, function(device){
+        count++;
+        if (count === 2) {
+          done();
+        }
+      });
+    });
+    
+    it('should return all test devices from quering .from(\'*\') when a new peer connects', function(done) {
+      var query = cloud.runtime.from('*').where({type: 'testdriver'});
+      var count = 0;
+      cloud.runtime.observe(query, function(device){
+        count++;
+        if (count === 3) {
+          done();
+        }
+      });
+
+      var z = zetta({ registry: new MemRegistry(), peerRegistry: new MemPeerRegistry() })
+        .name('local')
+        .use(Scout)
+        .silent()
+        .link('http://' + urlRoot)
+        .listen(0);
+    })
+
+    it('adding a device on the remote server should add a device to app with star query', function(done) {
+      var query = cloud.runtime.from('*').where({type: 'testdriver'});
+      var recv = 0;
+      cloud.runtime.observe([query], function(testdriver){
+        recv++;
+      });
+
+      var detroit = cluster.servers['detroit1'];
+      var scout = new FakeScout();
+      scout.server = detroit.runtime;
+      scout.discover(ExampleDevice);
+
+      setTimeout(function() {
+        assert.equal(recv, 3);
+        done();
+      }, 100);
     });
 
     it('should pass a remote query to peer socket through subscribe', function(done) {
@@ -141,6 +194,25 @@ describe('Remote queries', function() {
       });
     });
 
+    it('runtime should ony pass the device once to app for each peer', function(done) {
+      var query = cloud.runtime.from('*').where({type: 'testdriver'});
+      var recv = 0;
+      cloud.runtime.observe([query], function(testdriver){
+        recv++;
+      });
+      
+      var socket = cluster.servers['cloud'].httpServer.peers['detroit1'];
+      setTimeout(function(){
+        socket.close();
+      }, 100);
+
+      cloud.pubsub.subscribe('_peer/connect', function(ev, data) {
+        if (data.peer.name === 'detroit1') {
+          assert.equal(recv, 2);
+          done();
+        }
+      });
+    })
 
 
     it('should send back 1 result for peer after a reconnet', function(done) {


### PR DESCRIPTION
Example:

```js
module.exports = function(server) {
  var query = server.from('*').where({ type: 'led' });
  server.observe(query, function(device) {
    console.log('found led', device.id)
  });
};
```