### PR TITLE
Added custom properties to server.

### DIFF
--- a/lib/api_formats/siren/metadata.siren.js
+++ b/lib/api_formats/siren/metadata.siren.js
@@ -9,9 +9,7 @@ module.exports = function(context) {
 
   var entity = {
     class: ['metadata'],
-    properties: {
-      name: server._name
-    },
+    properties: server.getProperties(),
     entities: [],
     links: [
       { rel: ['self'], href: env.helpers.url.current() },

--- a/lib/api_formats/siren/server.siren.js
+++ b/lib/api_formats/siren/server.siren.js
@@ -10,9 +10,7 @@ module.exports = function(context) {
 
   var entity = {
     class: ['server'],
-    properties: {
-      name: server._name
-    },
+    properties: server.getProperties(),
     entities: [],
     actions: [
       {

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -86,6 +86,7 @@ describe('Zetta Api', function() {
     beforeEach(function(done) {
       app = zetta({ registry: reg, peerRegistry: peerRegistry })
         .silent()
+        .properties({ custom: 123 })
         .use(Scout)
         .use(HttpDriver)
         .name('local')
@@ -121,6 +122,16 @@ describe('Zetta Api', function() {
         .get(url)
         .expect(getBody(function(res, body) {
           assert.equal(body.properties.name, 'local');
+        }))
+        .end(done);
+    });
+
+    it('should have custom properties in resp', function(done) {
+      request(getHttpServer(app))
+        .get(url)
+        .expect(getBody(function(res, body) {
+          assert.equal(body.properties.name, 'local');
+          assert.equal(body.properties.custom, 123);
         }))
         .end(done);
     });

--- a/test/test_zetta.js
+++ b/test/test_zetta.js
@@ -28,6 +28,12 @@ describe('Zetta', function() {
     assert.equal(z._name, 'local');
   });
 
+  it('should throw error if setting name to *', function() {
+    assert.throws(function() {
+      var z = zetta({ registry: reg, peerRegistry: peerRegistry }).name('*').silent();
+    }, Error);
+  });
+
   it('has the silent() function to suppress logging.', function() {
     var z = zetta({ registry: reg, peerRegistry: peerRegistry }).name('local').silent();
   });
@@ -364,5 +370,16 @@ describe('Zetta', function() {
 
   });
 
+  it('has the properties() function to add custom properties to the api.', function() {
+    var z = zetta({ registry: reg, peerRegistry: peerRegistry });
+    assert(typeof z.properties, 'function');
+    z.properties({ test: 'abc' });
+  });
+
+  it('.getProperties() returns properties.', function() {
+    var z = zetta({ registry: reg, peerRegistry: peerRegistry }).name('test');
+    z.properties({ someKey: 123 });
+    assert.deepEqual(z.getProperties(), { name: 'test', someKey: 123 });
+  });
 
 });

--- a/zetta.js
+++ b/zetta.js
@@ -20,6 +20,7 @@ var Zetta = module.exports = function(opts) {
 
   this._name = os.hostname(); // optional name, defaults to OS hostname
   this.id = this._name;
+  this._properties = {}; // custom properties
 
   this._exposeQuery = '';
   this._scouts = [];
@@ -66,9 +67,31 @@ Zetta.prototype.logger = function(func) {
 };
 
 Zetta.prototype.name = function(name) {
+  if (name === '*') {
+    throw new Error('Cannot set name to *');
+  }
+
   this._name = name;
   this.id = this._name;
   return this;
+};
+
+Zetta.prototype.properties = function(props) {
+  var self = this;
+  if (typeof props === 'object') {
+    delete props.name; // cannot overide name
+    this._properties = props;
+  }
+  return this;
+};
+
+Zetta.prototype.getProperties = function() {
+  var self = this;
+  var ret = { name: this._name };
+  Object.keys(this._properties).forEach(function(k) {
+    ret[k] = self._properties[k];
+  });
+  return ret;
 };
 
 Zetta.prototype.use = function() {


### PR DESCRIPTION
Implements #154 

```js
zetta()
  .name('somename')
  .properties({ custom: 123 })
  .listen(0);
```
API response in `GET /servers/somename` will have properties set to `{ name: 'somename', custom: 123 }`.

You can fetch current properties with name as well using `.getProperties()`
