### PR TITLE
Fix for #202

### DIFF
--- a/lib/api_formats/siren/device.siren.js
+++ b/lib/api_formats/siren/device.siren.js
@@ -48,7 +48,9 @@ var buildActions = module.exports.buildActions = function(deviceId, env, loader,
 var buildStreamLinks = function(model, loader, env) {
   var links = [];
   var rootPath = env.helpers.url.path(loader.path);
-  var isSpdy = env.request && !!env.request.isSpdy;
+  var isForwardedProtocol = env.request && env.request.headers.hasOwnProperty('x-forwarded-proto') &&
+    ['http', 'https'].indexOf(env.request.headers['x-forwarded-proto']) !== -1;
+  var isSpdy = env.request && !!env.request.isSpdy && !isForwardedProtocol;
   var eventPath = isSpdy ? rootPath + '/events' : rootPath.replace(/^http/, 'ws') + '/events';
 
   var streams = model._streams;

--- a/lib/api_formats/siren/server.siren.js
+++ b/lib/api_formats/siren/server.siren.js
@@ -7,7 +7,9 @@ module.exports = function(context) {
   var loader = context.loader;
   var env = context.env;
 
-  var isSpdy = !!context.env.request.isSpdy;
+  var isForwardedProtocol = context.env.request.headers.hasOwnProperty('x-forwarded-proto') &&
+    ['http', 'https'].indexOf(context.env.request.headers['x-forwarded-proto']) !== -1;
+  var isSpdy = !!context.env.request.isSpdy && !isForwardedProtocol;
 
   var rootPath = env.helpers.url.path(loader.path);
   var eventPath = isSpdy ? rootPath  + '/events' : rootPath.replace(/^http/, 'ws') + '/events';

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -165,19 +165,25 @@ ZettaHttpServer.prototype.collector = function(name, collector) {
   return this;
 };
 
+function getCurrentProtocol(req) {
+  var xfp = req.headers['x-forwarded-proto'];
+  var protocol;
+
+  if (xfp && xfp.length) {
+    protocol = xfp.replace(/\s*/, '').split(',')[0];
+  } else {
+    protocol = req.connection.encrypted ? 'https' : 'http';
+  }
+
+  return protocol;
+}
+
 ZettaHttpServer.prototype.wireUpWebSocketForEvent = function(ws, host, p) {
   ws._env = { helpers: {}};
   ws._loader = { path: p };
 
   ws._env.uri = function() {
-    var xfp = ws.upgradeReq.headers['x-forwarded-proto'];
-    var protocol;
-
-    if (xfp && xfp.length) {
-      protocol = xfp.replace(/\s*/, '').split(',')[0];
-    } else {
-      protocol = ws.upgradeReq.connection.encrypted ? 'https' : 'http';
-    }
+    var protocol = getCurrentProtocol(ws.upgradeReq);
 
     if (!host) {
       var address = ws.upgradeReq.connection.address();
@@ -307,6 +313,7 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
 
   var req = env.request;
   var res = env.response;
+  var protocol = getCurrentProtocol(req);
 
   var messageId = ++self.idCounter;
   self.clients[messageId] = res;
@@ -324,6 +331,10 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
 
       headers['zetta-message-id'] = messageId;
       headers['zetta-forwarded-server'] = name;
+
+      if (!req.isSpdy) {
+        headers['x-forwarded-proto'] = protocol;
+      }
 
       var peer = self.peers[name];
       if (!peer || peer.state !== PeerSocket.CONNECTED){
@@ -369,6 +380,9 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
 
   req.headers['zetta-message-id'] = messageId;
   req.headers['zetta-forwarded-server'] = name;
+  if (!req.isSpdy) {
+    req.headers['x-forwarded-proto'] = getCurrentProtocol(req);
+  }
 
   var peer = self.peers[name];
   if (!peer){


### PR DESCRIPTION
This change adds a check to see if the request is being forwarded from one Zetta server to another using HTTP or HTTPS.  If so, it sets headers accordingly and makes sure event link URLs come back with ws(s):// schemes.  If the connection is SPDY, it will use http(s):// schemes for events.  Tests included.