### PR TITLE
Allowing zetta users to extend websocket model with server extensions.

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -22,6 +22,7 @@ var rels = require('zetta-rels');
 var querytopic = require('./query_topic');
 
 var ZettaHttpServer = module.exports = function(zettaInstance) {
+  var self = this;
   this.idCounter = 0;
   this.zetta = zettaInstance;
   this.peerRegistry = zettaInstance.peerRegistry;
@@ -41,6 +42,70 @@ var ZettaHttpServer = module.exports = function(zettaInstance) {
     windowSize: 1024 * 1024,
     plain: true,
     ssl: false
+  });
+
+  this.wss = new WebSocketServer({ noServer: true });
+  this.server.on('upgrade', function(request, socket, headers) {
+    function match(request) {
+      if(/^\/peers\/(.+)$/.exec(request.url)) {
+        return true; 
+      } else if(request.url === '/peer-management') {
+        return true;
+      } else if(/^\/servers\/(.+)\/events/.exec(request.url)) {
+        return true;
+      } else if(/^\/events/.exec(request.url)) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    if(match(request)) {
+      self.wss.handleUpgrade(request, socket, headers, function(ws) {
+        var match = /^\/peers\/(.+)$/.exec(ws.upgradeReq.url);
+        if (match) {
+          var name = /^\/peers\/(.+)$/.exec(url.parse(ws.upgradeReq.url, true).pathname)[1];
+          name = decodeURI(name);
+          self.zetta.log.emit('log', 'http_server', 'Websocket connection for peer "' + name + '" established.');
+
+          if (self.peers[name] && self.peers[name].state !== PeerSocket.DISCONNECTED) {
+            // peer already connected or connecting
+            ws.close(4000, 'peer already connected');
+          } else if (self.peers[name]) {
+            // peer has been disconnected but has connected before.
+            self.peers[name].init(ws);
+          } else {
+            var peer = new PeerSocket(ws, name, self.peerRegistry);
+            self.peers[name] = peer;
+
+            peer.on('connected', function() {
+              self.eventBroker.peer(peer);
+              self.zetta.log.emit('log', 'http_server', 'Peer connection established "' + name + '".');
+              self.zetta.pubsub.publish('_peer/connect', { peer: peer });
+            });
+
+            peer.on('error', function(err) {
+              self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
+              self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+            });
+
+            peer.on('end', function() {
+              self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
+              self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+            });
+          }
+        } else if (ws.upgradeReq.url === '/peer-management') {
+          var query = [
+            { name: self.zetta.id, topic: '_peer/connect' },
+            { name: self.zetta.id, topic: '_peer/disconnect' }];
+
+          var client = new EventSocket(ws, query);
+          self.eventBroker.client(client);
+        } else {
+          self.setupEventSocket(ws);
+        }
+      });
+    }
   });
 
   this.cloud = argo()
@@ -94,52 +159,6 @@ ZettaHttpServer.prototype.init = function(cb) {
 
   this.server.on('request', this.cloud.run);
   this.spdyServer.on('request', this.cloud.run);
-
-  this.wss = new WebSocketServer({ server: this.server });
-  this.wss.on('connection', function(ws) {
-    var match = /^\/peers\/(.+)$/.exec(ws.upgradeReq.url);
-    if (match) {
-      var name = /^\/peers\/(.+)$/.exec(url.parse(ws.upgradeReq.url, true).pathname)[1];
-      name = decodeURI(name);
-      self.zetta.log.emit('log', 'http_server', 'Websocket connection for peer "' + name + '" established.');
-
-      if (self.peers[name] && self.peers[name].state !== PeerSocket.DISCONNECTED) {
-        // peer already connected or connecting
-        ws.close(4000, 'peer already connected');
-      } else if (self.peers[name]) {
-        // peer has been disconnected but has connected before.
-        self.peers[name].init(ws);
-      } else {
-        var peer = new PeerSocket(ws, name, self.peerRegistry);
-        self.peers[name] = peer;
-
-        peer.on('connected', function() {
-          self.eventBroker.peer(peer);
-          self.zetta.log.emit('log', 'http_server', 'Peer connection established "' + name + '".');
-          self.zetta.pubsub.publish('_peer/connect', { peer: peer });
-        });
-
-        peer.on('error', function(err) {
-          self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
-          self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
-        });
-
-        peer.on('end', function() {
-          self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
-          self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
-        });
-      }
-    } else if (ws.upgradeReq.url === '/peer-management') {
-      var query = [
-        { name: self.zetta.id, topic: '_peer/connect' },
-        { name: self.zetta.id, topic: '_peer/disconnect' }];
-
-      var client = new EventSocket(ws, query);
-      self.eventBroker.client(client);
-    } else {
-      self.setupEventSocket(ws);
-    }
-  });
 
   if (cb) {
     cb();


### PR DESCRIPTION
WIP branch for now. We have to do funky stuff to allow folks to extend zetta via websockets. Here is what the changes entail. This aims to fix #208.

1. We removed the web socket server setup from the `init()` function on `lib/http_server.js` and put it in the constructor.
2. We updated the web socket server to have us manually handle upgrades through it via the `noServer` flag
3. On the `upgrade` event from the http / spdy server we parse the URL to check if it's one of the following
  * `/peers`
  * `/peer-management`
  * `/servers/serverId/events`
  * `/events`
4. If it is one of those reserved urls we then pass the handle event arguments to the web socket server, and create the connection.
5. We then handle the web socket as we would normally in the old code.

We had to do this because:

1. The `path` option in the web socket server implementation is just a simple string match. If you instantiated a web socket server with a path option of `/test` any incoming connection requests would go through for only the path `/test` not `/test/foo` or `/test/123`. This was a giant bummer.

I may have missed something trying to tackle this. So I have no problem scrapping this in favor of something more built in.

I need tests as well still. 