### PR TITLE
Hooks for remoteUpdate and remoteFetch

### DIFF
--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -357,31 +357,14 @@ ServerResource.prototype.updateDevice = function(env, next) {
       return next(env);
     }
 
+    if (typeof device._handleRemoteUpdate !== 'function') {
+      env.response.statusCode = 501;
+      return next(env);
+    }
+
     // TODO: Check for conditional PUT using ETag.
 
-    var reserved = ['id', 'streams', 'type', 'state'];
-    var monitors = device._monitors;
-
-    var inputKeys = Object.keys(input);
-    var acceptableKeyFilter = function(key) {
-      return key[0] !== '_' && reserved.indexOf(key) === -1 && monitors.indexOf(key) === -1;
-    };
-
-    inputKeys
-      .filter(acceptableKeyFilter)
-      .forEach(function(key) {
-        device[key] = input[key];
-      });
-
-    Object.keys(device)
-      .filter(acceptableKeyFilter)
-      .forEach(function(key) {
-        if (inputKeys.indexOf(key) === -1) {
-          delete device[key];
-        }
-      });
-
-    device.save(function(err) {
+    device._handleRemoteUpdate(input, function(err) {
       if (err) {
         env.response.statusCode = 500;
         return next(env);
@@ -395,16 +378,6 @@ ServerResource.prototype.updateDevice = function(env, next) {
       };
 
       env.format.render('device', model);
-
-      var topic = device.type + '/' + device.id + '/logs';
-      var json = ObjectStream.format(topic, null);
-      delete json.data;
-      json.transition = 'zetta-properties-update';
-      json.input = [];
-      json.properties = device.properties();
-      json.transitions = device.transitionsAvailable();
-      self.server.pubsub.publish(topic, json);
-
       next(env);
     });
   });

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "titan": "~0.1.1",
     "ws": "^0.4.31",
     "zetta-auto-scout": "^0.8.0",
-    "zetta-device": "^0.11.0",
+    "zetta-device": "^0.12.0",
     "zetta-http-device": "^0.4.0",
     "zetta-rels": "^0.4.0",
-    "zetta-scientist": "^0.3.0",
+    "zetta-scientist": "^0.4.0",
     "zetta-scout": "^0.5.0",
     "zetta-streams": "^0.2.0"
   },


### PR DESCRIPTION
Needs https://github.com/zettajs/zetta-device/pull/11 and https://github.com/zettajs/zetta-scientist/pull/2 to be merged first.

Device API and Z2Z - Returns the default remoteFetch method of the user supplied one. Then appends name, id, state, and type to that object. This is done using the device's `.properties()` method.

Device Update API - Uses the device's `_remoteUpdateHandler` method to update properties on the device. If device is using old version of zetta-device that does not support updates API returns a 501.

Zetts-device handles this by first filtering all reserved keys out, then calls the default remoteUpdate method or the user supplied one. Then triggers the zetta-properties-update transition. The default remoteUpdate filters all monitor values out and deletes any key the device that does not exist in the new input and saves new properties to the registry.