### PR TITLE
Decoding transition args to number/string/date based on input type in driver

### DIFF
--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -430,16 +430,16 @@ ServerResource.prototype.deviceAction = function(env, next) {
     var args = [body.action];
 
     if (action.fields && action.fields.length) {
-
-      var argsOk = action.fields.every(function(field) {
+      
+      var parseErrors = [];
+      action.fields.forEach(function(field) {
         if (field.name !== 'action') {
           var arg = body[field.name];
           if (field.type === 'number') {
             arg = Number(arg);
 
             if (isNaN(arg)) {
-              env.response.body = 'Invalid argument. Field "' + field.name  + '" expected to be a Number.';
-              return false;
+              parseErrors.push('Field "' + field.name  + '" expected to be a Number.');
             }
           } else if (field.type === 'date') {
             // HTML5 secifies YYYY-MM-DD for transfer over the wire. Convert it to YYYY/MM/DD for js Date object parsing
@@ -447,19 +447,27 @@ ServerResource.prototype.deviceAction = function(env, next) {
 
             // test if date parsed correctly
             if (isNaN(arg.getTime())) {
-              env.response.body = 'Invalid argument. Field "' + field.name  + '" expected to be a Date. eg YYYY-MM-DD';
-              return false;
+              parseErrors.push('Field "' + field.name  + '" expected to be a Date. eg YYYY-MM-DD');
             }
           }
           args.push(arg);
-          return true;
         }
       });
 
       
       // Test is any did not decode properly
-      if (!argsOk) {
+      if (parseErrors.length > 0) {
         env.response.statusCode = 400;
+        env.response.body = {
+          class: ['input-error'],
+          properties: {
+            message: 'Invalid argument(s)',
+            errors: parseErrors
+          },
+          links: [
+            { rel: ['self'], href: env.helpers.url.current() }
+          ]
+        };
         return next(env);
       }
     }

--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -430,18 +430,38 @@ ServerResource.prototype.deviceAction = function(env, next) {
     var args = [body.action];
 
     if (action.fields && action.fields.length) {
-      action.fields.forEach(function(field) {
+
+      var argsOk = action.fields.every(function(field) {
         if (field.name !== 'action') {
           var arg = body[field.name];
           if (field.type === 'number') {
             arg = Number(arg);
+
+            if (isNaN(arg)) {
+              env.response.body = 'Invalid argument. Field "' + field.name  + '" expected to be a Number.';
+              return false;
+            }
           } else if (field.type === 'date') {
             // HTML5 secifies YYYY-MM-DD for transfer over the wire. Convert it to YYYY/MM/DD for js Date object parsing
             arg = new Date(arg.replace(/-/g, "/"));
+
+            // test if date parsed correctly
+            if (isNaN(arg.getTime())) {
+              env.response.body = 'Invalid argument. Field "' + field.name  + '" expected to be a Date. eg YYYY-MM-DD';
+              return false;
+            }
           }
           args.push(arg);
+          return true;
         }
       });
+
+      
+      // Test is any did not decode properly
+      if (!argsOk) {
+        env.response.statusCode = 400;
+        return next(env);
+      }
     }
 
     var cb = function(err) {

--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -432,7 +432,14 @@ ServerResource.prototype.deviceAction = function(env, next) {
     if (action.fields && action.fields.length) {
       action.fields.forEach(function(field) {
         if (field.name !== 'action') {
-          args.push(body[field.name]);
+          var arg = body[field.name];
+          if (field.type === 'number') {
+            arg = Number(arg);
+          } else if (field.type === 'date') {
+            // HTML5 secifies YYYY-MM-DD for transfer over the wire. Convert it to YYYY/MM/DD for js Date object parsing
+            arg = new Date(arg.replace(/-/g, "/"));
+          }
+          args.push(arg);
         }
       });
     }

--- a/test/fixture/example_driver.js
+++ b/test/fixture/example_driver.js
@@ -18,7 +18,7 @@ TestDriver.prototype.init = function(config) {
     .state('ready')
     .type('testdriver')
     .name('Matt\'s Test Device')
-    .when('ready', { allow: ['change', 'test', 'error'] })
+    .when('ready', { allow: ['change', 'test', 'error', 'test-number', 'test-text', 'test-none', 'test-date'] })
     .when('changed', { allow: ['prepare', 'test', 'error'] })
     .map('change', this.change)
     .map('prepare', this.prepare)
@@ -26,7 +26,11 @@ TestDriver.prototype.init = function(config) {
     .map('error', this.returnError, [{ name: 'error', type: 'string'}])
     .monitor('foo')
     .stream('bar', this.streamBar)
-    .stream('foobar', this.streamFooBar, {binary: true});
+    .stream('foobar', this.streamFooBar, {binary: true})
+    .map('test-number', function(x, cb) { cb(); }, [{ name: 'value', type: 'number'}])
+    .map('test-text', function(x, cb) { cb(); }, [{ name: 'value', type: 'text'}])
+    .map('test-none', function(x, cb) { cb(); }, [{ name: 'value'}])
+    .map('test-date', function(x, cb) { cb(); }, [{ name: 'value', type: 'date'}])
 };
 
 TestDriver.prototype.test = function(value, cb) {

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -750,9 +750,10 @@ describe('Zetta Api', function() {
         .post(url)
         .type('form')
         .expect(400)
-        .expect(function(res) {
-          assert(res.text.indexOf('Invalid argument.') > -1);
-        })
+        .expect(getBody(function(res, body) {
+          assert(body.class.indexOf('input-error') > -1);
+          assert.equal(body.properties.errors.length, 1);
+        }))
         .send({ action: 'test-number', value: 'some string' })
         .end(done);
     })
@@ -762,9 +763,10 @@ describe('Zetta Api', function() {
         .post(url)
         .type('form')
         .expect(400)
-        .expect(function(res) {
-          assert(res.text.indexOf('Invalid argument.') > -1);
-        })
+        .expect(getBody(function(res, body) {
+          assert(body.class.indexOf('input-error') > -1);
+          assert.equal(body.properties.errors.length, 1);
+        }))
         .send({ action: 'test-date', value: 'some string' })
         .end(done);
     })

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -568,7 +568,7 @@ describe('Zetta Api', function() {
       request(getHttpServer(app))
         .get(url)
         .expect(getBody(function(res, body) {
-          assert.equal(body.actions.length, 3);
+          assert.equal(body.actions.length, 7);
           var action = body.actions[0];
           assert.equal(action.name, 'change');
           assert.equal(action.method, 'POST');
@@ -582,7 +582,7 @@ describe('Zetta Api', function() {
       request(getHttpServer(app))
         .get(url)
         .expect(getBody(function(res, body) {
-          assert.equal(body.actions.length, 3);
+          assert.equal(body.actions.length, 7);
           body.actions.forEach(function(action) {
             assert(action.class.indexOf('transition') >= 0);
           })
@@ -719,6 +719,32 @@ describe('Zetta Api', function() {
         }))
         .end(done);
     });
+
+
+    var createTransitionArgTest = function(action, testType, input) {
+      it('api should decode transition args to ' + testType + ' for ' + action, function(done) {
+        var device = app.runtime._jsDevices[Object.keys(app.runtime._jsDevices)[0]];
+        
+        var orig = device._transitions[action].handler;
+        device._transitions[action].handler = function(x) {
+          assert.equal(typeof x, testType);
+          orig.apply(device, arguments);
+        };
+        
+        request(getHttpServer(app))
+          .post(url)
+          .type('form')
+          .expect(200)
+          .send({ action: action, value: input })
+          .end(done);
+      });
+    };
+    
+    createTransitionArgTest('test-number', 'number', 123)
+    createTransitionArgTest('test-text', 'string', 'Hello');
+    createTransitionArgTest('test-none', 'string', 'Anything');
+    createTransitionArgTest('test-date', 'object', '2015-01-02');
+    createTransitionArgTest('test-date', 'object', 'asdasd');
 
     it('device action should return 400 when not available.', function(done) {
       request(getHttpServer(app))

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -744,7 +744,30 @@ describe('Zetta Api', function() {
     createTransitionArgTest('test-text', 'string', 'Hello');
     createTransitionArgTest('test-none', 'string', 'Anything');
     createTransitionArgTest('test-date', 'object', '2015-01-02');
-    createTransitionArgTest('test-date', 'object', 'asdasd');
+
+    it('api should respond with 400 when argument is not expected number', function(done) {
+      request(getHttpServer(app))
+        .post(url)
+        .type('form')
+        .expect(400)
+        .expect(function(res) {
+          assert(res.text.indexOf('Invalid argument.') > -1);
+        })
+        .send({ action: 'test-number', value: 'some string' })
+        .end(done);
+    })
+
+    it('api should respond with 400 when argument is not expected Date', function(done) {
+      request(getHttpServer(app))
+        .post(url)
+        .type('form')
+        .expect(400)
+        .expect(function(res) {
+          assert(res.text.indexOf('Invalid argument.') > -1);
+        })
+        .send({ action: 'test-date', value: 'some string' })
+        .end(done);
+    })
 
     it('device action should return 400 when not available.', function(done) {
       request(getHttpServer(app))

--- a/test/test_virtual_device.js
+++ b/test/test_virtual_device.js
@@ -94,7 +94,7 @@ describe('Virtual Device', function() {
     });
 
     it('call should work with arguments', function(done) {
-      vdevice.call('test', 'hello', function(err) {
+      vdevice.call('test', 321, function(err) {
         assert.equal(err, null);
       });
       var timer = setTimeout(function() {
@@ -103,7 +103,7 @@ describe('Virtual Device', function() {
 
       device.on('test', function() {
         clearTimeout(timer);
-        assert.equal(device.value, 'hello');
+        assert.equal(device.value, 321);
         done();
       });
     });
@@ -114,17 +114,17 @@ describe('Virtual Device', function() {
         done(new Error('Faied to recv transition call on detroit device'));
       }, 1500);
 
-      vdevice.call('test', 'hello', function(err) {
+      vdevice.call('test', 999, function(err) {
         assert.equal(err, null);
 
         clearTimeout(timer);
-        assert.equal(device.value, 'hello');
+        assert.equal(device.value, 999);
 
         var socket = cluster.servers['cloud'].httpServer.peers['detroit1'];
         socket.close();
 
         setTimeout(function() {
-          vdevice.call('test', 'hello1', function(err) {
+          vdevice.call('test', 222, function(err) {
             assert.equal(err, null);
           });
           var timer = setTimeout(function() {
@@ -133,7 +133,7 @@ describe('Virtual Device', function() {
 
           device.on('test', function() {
             clearTimeout(timer);
-            assert.equal(device.value, 'hello1');
+            assert.equal(device.value, 222);
             done();
           });
         }, 1500);


### PR DESCRIPTION
Currently only parsing `number` and `date` input types to their native counterpart in JS. All other listed in Siren spec don't have native type in JS.

`hidden`, `text`, `search`, `tel`, `url`, `email`, `password`, `datetime`, `date`,
`month`, `week`, `time`, `datetime-local`, 
`number`, `range`, `color`, `checkbox`,
`radio`, `file` 

Question: if the input arg parses to a `NaN` or not a date should we return a 400. Currently it's not, those are passed to the driver. @mdobson @kevinswiber 

