### PR TITLE
Fixing two bugs in the runtime.

### DIFF
--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -312,7 +312,7 @@ ServerResource.prototype.destroyDevice = function(env, next) {
     return next(env);
   }
 
-  if (typeof device._handleRemoteUpdate !== 'function') {
+  if (typeof device._handleRemoteDestroy !== 'function') {
     env.response.statusCode = 501;
     return next(env);
   }

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -313,7 +313,7 @@ Runtime.prototype._onDestroy = function(device, cb) {
   }
   this._destroyDevice(device, function(err) {
     if(err) {
-     self.log.emit('error', 'server', 'Device (' + device.id + ') could not be deleted. Error: ' + err.message); 
+     self._log.emit('error', 'server', 'Device (' + device.id + ') could not be deleted. Error: ' + err.message); 
     }
     
     cb(err);  
@@ -338,6 +338,7 @@ Runtime.prototype._destroyDevice = function(device, cb) {
       });
     }); 
   } else {
-    self.log.emit('error', 'server', 'Device (' + device.id + ') could not be deleted. Error: Device incompatible with delete functionality.'); 
+    self._log.emit('error', 'server', 'Device (' + device.id + ') could not be deleted. Error: Device incompatible with delete functionality.'); 
+    cb(new Error('Device not compatible'));
   }
 };

--- a/test/test_runtime.js
+++ b/test/test_runtime.js
@@ -252,6 +252,22 @@ describe('Runtime', function(){
         });
       });
     });
+
+    it('_destroyDevice callback will pass an error if _sendLogStreamEvent is not a function on the device prototype.', function(done) {
+      var emitter = new EventEmitter();
+      emitter.id = '1';
+      emitter.type = 'test1';
+      emitter._sendLogStreamEvent = null;
+      runtime._jsDevices['1'] = emitter;
+      runtime.registry.db.put('1', {'id': '1', 'type': 'test1'}, {valueEncoding: 'json'}, function() {
+        runtime.emit('deviceready', emitter);
+        runtime._destroyDevice(emitter, function(err) {
+          assert.ok(err);
+          assert.equal(err.message, 'Device not compatible');
+          done();
+        });
+      });
+    });
   });
 
   describe('Extended reactive syntax', function() {


### PR DESCRIPTION
- Trying to emit to `this.log` when it should be `this._log`
- Callback not called on `_destroyDevice()` if device isn't compatible with new delete functionality. 