### PR TITLE
Zetta-to-Zetta Protocol Changes

### DIFF
--- a/lib/api_resources/devices.js
+++ b/lib/api_resources/devices.js
@@ -1,3 +1,4 @@
+var url = require('url');
 var MediaType = require('api-media-type');
 
 var DevicesResource = module.exports = function(server) {
@@ -14,7 +15,11 @@ DevicesResource.prototype.init = function(config) {
 };
 
 DevicesResource.prototype.list = function(env, next) {
-  var serverId = env.request.headers['zetta-forwarded-server'] || this.server.id;
+  var parsed = url.parse(env.request.url);
+  var re = /^\/servers\/([^\/]+)/;
+  var match = re.exec(parsed.pathname);
+  
+  var serverId = match && match[1] ? match[1] : this.server.id;
 
   var localServer = { path: '/servers/'+ encodeURI(serverId) };
   var context = { devices: this.server.runtime._jsDevices, loader: localServer, env: env };

--- a/lib/api_resources/root.js
+++ b/lib/api_resources/root.js
@@ -87,22 +87,13 @@ RootResource.prototype.list = function(env, next) {
               var response = obj.res;
               var body = obj.body;
 
-              var id = response.headers['zetta-message-id'];
-
-              if (!messageId) {
-                messageId = id;
-              }
-
-              var res = httpServer.clients[id];
-
+              var res = httpServer.clients[messageId];
               if (!res) {
                 return [];
               }
 
               Object.keys(response.headers).forEach(function(header) {
-                if (header !== 'zetta-message-id') {
-                  res.setHeader(header, response.headers[header]);
-                }
+                res.setHeader(header, response.headers[header]);
               });
 
               res.statusCode = response.statusCode;

--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -14,7 +14,11 @@ var ServerResource = module.exports = function(server) {
 };
 
 ServerResource.prototype.getServer = function(env) {
-  var serverId = env.request.headers['zetta-forwarded-server'] || this.server.id;
+  var parsed = url.parse(env.request.url);
+  var re = /^\/servers\/([^\/]+)/;
+  var match = re.exec(parsed.pathname);
+  
+  var serverId = match && match[1] ? match[1] : this.server.id;
 
   return { path: '/servers/' + encodeURI(serverId) };
 };

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -123,14 +123,6 @@ var ZettaHttpServer = module.exports = function(zettaInstance) {
     })
     .use(function(handle) {
       handle('request', function(env, next) {
-        if (env.request.headers['zetta-message-id']) {
-          env.response.setHeader('zetta-message-id', env.request.headers['zetta-message-id']);
-        }
-        next(env);
-      });
-    })
-    .use(function(handle) {
-      handle('request', function(env, next) {
         if (env.request.method === 'OPTIONS') {
           env.argo._routed = true;
         }
@@ -348,8 +340,6 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
         headers[key] = req.headers[key];
       });
 
-      headers['zetta-message-id'] = messageId;
-
       if (!req.isSpdy) {
         headers['x-forwarded-proto'] = protocol;
       }
@@ -398,7 +388,6 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
   var parsed = url.parse(req.url);
   var name = decodeURIComponent(parsed.pathname.split('/')[2]);
 
-  req.headers['zetta-message-id'] = messageId;
   if (!req.isSpdy) {
     req.headers['x-forwarded-proto'] = getCurrentProtocol(req);
   }
@@ -414,8 +403,7 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
 
   var opts = { method: req.method, headers: req.headers, path: req.url, agent: agent };
   var request = http.request(opts, function(response) {
-    var id = response.headers['zetta-message-id'];
-    var res = self.clients[id];
+    var res = self.clients[messageId];
 
     if (!res) {
       response.statusCode = 404;
@@ -423,9 +411,7 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
     }
 
     Object.keys(response.headers).forEach(function(header) {
-      if (header !== 'zetta-message-id') {
-        res.setHeader(header, response.headers[header]);
-      }
+      res.setHeader(header, response.headers[header]);
     });
 
     res.statusCode = response.statusCode;
@@ -442,7 +428,7 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
       if(!opts.pipe) {
         env.response.body = buf.toString();  
       }
-      delete self.clients[id];
+      delete self.clients[messageId];
       next(env);
     });
 

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -349,7 +349,6 @@ ZettaHttpServer.prototype.proxyToPeers = function(peers, env, cb) {
       });
 
       headers['zetta-message-id'] = messageId;
-      headers['zetta-forwarded-server'] = name;
 
       if (!req.isSpdy) {
         headers['x-forwarded-proto'] = protocol;
@@ -400,7 +399,6 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
   var name = decodeURIComponent(parsed.pathname.split('/')[2]);
 
   req.headers['zetta-message-id'] = messageId;
-  req.headers['zetta-forwarded-server'] = name;
   if (!req.isSpdy) {
     req.headers['x-forwarded-proto'] = getCurrentProtocol(req);
   }

--- a/lib/peer_socket.js
+++ b/lib/peer_socket.js
@@ -227,7 +227,11 @@ PeerSocket.prototype.onPushData = function(stream) {
     stream.connection.end();
   }
 
-  var encoding = stream.headers['x-event-encoding'] || 'json';
+  var encoding = stream.headers['content-type'] || 'application/json';
+  // remove additional parameters such as in `application/json; charset=utf-8`
+  if (encoding.indexOf(';') !== -1) {
+    encoding = encoding.split(';')[0].trim(); 
+  }
   var length = Number(stream.headers['content-length']);
   var data = new Buffer(length);
   var idx = 0;
@@ -246,13 +250,13 @@ PeerSocket.prototype.onPushData = function(stream) {
 
   stream.on('end', function() {
     var body = null;
-    if (encoding === 'json') {
+    if (encoding === 'application/json') {
       try {
         body = JSON.parse(data.toString());
       } catch (err) {
         console.error('PeerSocket push data json parse error', err);
       }
-    } else if(encoding === 'buffer') {
+    } else if(encoding === 'application/octet-stream') {
       body = data;
     }
     self.emit(streamUrl, body);

--- a/lib/peer_socket.js
+++ b/lib/peer_socket.js
@@ -290,7 +290,7 @@ PeerSocket.prototype.subscribe = function(event, cb) {
   if(this.ws && this.ws.upgradeReq) {
     host = this.ws.upgradeReq.headers.host
   } else {
-    host = 'fog.argo.cx';
+    host = encodeURIComponent(this.name) + '.unreachable.zettajs.io';
   }
 
   var opts = {
@@ -333,7 +333,7 @@ PeerSocket.prototype.unsubscribe = function(event, cb) {
   if(this.ws && this.ws.upgradeReq) {
     host = this.ws.upgradeReq.headers.host
   } else {
-    host = 'fog.argo.cx';
+    host = encodeURIComponent(this.name) + '.unreachable.zettajs.io';
   }
 
   var body = new Buffer('topic='+event);
@@ -383,7 +383,7 @@ PeerSocket.prototype.transition = function(action, args, cb) {
   if(this.ws && this.ws.upgradeReq) {
     host = this.ws.upgradeReq.headers.host
   } else {
-    host = 'fog.argo.cx';
+    host = encodeURIComponent(this.name) + '.unreachable.zettajs.io';
   }
 
   var opts = {

--- a/lib/pubsub_service.js
+++ b/lib/pubsub_service.js
@@ -71,14 +71,14 @@ PubSub.prototype._onResponse = function(topic, env) {
   return function(data) {
     var encoding = '';
     if(Buffer.isBuffer(data)) {
-      encoding = 'buffer';
+      encoding = 'application/octet-stream';
     } else if (data.query && data.device) {
       var serverId = env.route.params.serverId;
       var loader = { path: '/servers/' + encodeURI(serverId) };
       data = deviceFormatter({ loader: loader, env: env, model: data.device });      
       data = new Buffer(JSON.stringify(data));
     } else if (typeof data == 'object') {
-      encoding = 'json';
+      encoding = 'application/json';
       try {
         data = new Buffer(JSON.stringify(data));
       } catch (err) {
@@ -91,7 +91,7 @@ PubSub.prototype._onResponse = function(topic, env) {
 
     var stream = env.response.push('/' + topic, { 'Host': 'fog.argo.cx',
                                    'Content-Length': data.length,
-                                   'X-Event-Encoding': encoding
+                                   'Content-Type': encoding
                                  });
 
     stream.on('error', function(err) {

--- a/lib/pubsub_service.js
+++ b/lib/pubsub_service.js
@@ -74,7 +74,7 @@ PubSub.prototype._onResponse = function(topic, env) {
       encoding = 'application/octet-stream';
     } else if (data.query && data.device) {
       var serverId = env.route.params.serverId;
-      var loader = { path: '/servers/' + encodeURI(serverId) };
+      var loader = { path: '/servers/' + encodeURIComponent(serverId) };
       data = deviceFormatter({ loader: loader, env: env, model: data.device });      
       data = new Buffer(JSON.stringify(data));
     } else if (typeof data == 'object') {
@@ -89,7 +89,7 @@ PubSub.prototype._onResponse = function(topic, env) {
       console.error('PubSub._onResponse encoding not set.');
     }
 
-    var stream = env.response.push('/' + topic, { 'Host': 'fog.argo.cx',
+    var stream = env.response.push('/' + topic, { 'Host': encodeURIComponent(serverId) + '.unreachable.zettajs.io',
                                    'Content-Length': data.length,
                                    'Content-Type': encoding
                                  });


### PR DESCRIPTION
**Note: These changes are not backwards-compatible.  All previous versions will need to be upgraded.**

* Remove zetta-forwarded-server header:  This information can be parsed out of the request URL.
* Remove zetta-message-id header: This information can be obtained by passing around response references.
* Change X-Event-Encoding header to Content-Type: Instead of using `json` and `buffer` as the values, favor `application/json` and `application/octet-stream`.
* Change Host header from `fog.argo.cx` to `{{server-id}}.unreachable.zettajs.io`.