### PR TITLE
Peer management updates

### DIFF
--- a/lib/api_resources/peer_management.js
+++ b/lib/api_resources/peer_management.js
@@ -296,8 +296,7 @@ PeerManagementBuilder.prototype.entities = function() {
       var peerUrlRel = peer.direction === 'initiator' ? rels.root : rels.server;
       entity.links = [
         { rel: [rels.self], href: self.urlHelper.join(encodeURI(peer.id)) },
-        { rel: [peerUrlRel], href: peerUrl },
-        { rel: [rels.monitor], href: peerUrl.replace(/^http/, 'ws') }
+        { rel: [peerUrlRel], href: peerUrl }
       ];
 
       return entity;
@@ -378,8 +377,7 @@ PeerItemBuilder.prototype.links = function() {
   var peerUrlRel = self.base.properties.direction === 'initiator' ? rels.root : rels.server;
   this.base.links = [
     { rel: [rels.self], href: self.urlHelper.current() },
-    { rel: [peerUrlRel], href: peerUrl },
-    { rel: [rels.monitor], href: peerUrl.replace(/^http/, 'ws') }
+    { rel: [peerUrlRel], href: peerUrl }
   ];
 
   return this;

--- a/lib/api_resources/peer_management.js
+++ b/lib/api_resources/peer_management.js
@@ -236,6 +236,10 @@ PeerManagementResource.prototype.show = function(env, next) {
   });
 };
 
+function shouldAddActionsToPeer(peer) {
+  return peer.direction === 'initiator' || peer.status === 'connected';
+}
+
 var PeerManagementBuilder = function(data, urlHelper) {
   this.data = data || {};
   this.urlHelper = urlHelper;
@@ -275,7 +279,7 @@ PeerManagementBuilder.prototype.entities = function() {
       entity.actions = [];
 
       // when direction is acceptor, only show actions when connected
-      if (peer.direction === 'initiator' || peer.status === 'connected') {
+      if (shouldAddActionsToPeer(peer)) {
         entity.actions.push({
           name: 'disconnect',
           method: 'DELETE',
@@ -351,23 +355,16 @@ PeerItemBuilder.prototype.properties = function() {
 PeerItemBuilder.prototype.actions = function() {
   this.base.actions = [];
 
-  this.base.actions.push({
-    name: 'disconnect',
-    method: 'DELETE',
-    href: this.urlHelper.path('/peer-management/'+this.data.connectionId),
-  },{
-    name: 'update',
-    method: 'PUT',
-    href: this.urlHelper.path('/peer-management/'+this.data.connectionId),
-    fields: [{name: 'url', type: 'url'}]
-  });  
-
-  if (this.data.direction === 'initiator') {
+  if (shouldAddActionsToPeer(this.data)) {
     this.base.actions.push({
-      name: 'reconnect',
-      method: 'POST',
-      href: this.urlHelper.path('/peer-management'),
-      fields: [{ name: 'url', type: 'url', value: this.data.url }]
+      name: 'disconnect',
+      method: 'DELETE',
+      href: this.urlHelper.path('/peer-management/'+this.data.connectionId),
+    },{
+      name: 'update',
+      method: 'PUT',
+      href: this.urlHelper.path('/peer-management/'+this.data.connectionId),
+      fields: [{name: 'url', type: 'url'}]
     });
   }
 

--- a/lib/api_resources/peer_management.js
+++ b/lib/api_resources/peer_management.js
@@ -117,28 +117,17 @@ PeerManagementResource.prototype.updatePeer = function(env, next) {
       if(results.length) {
         var peer = results[0];
         if(peer.direction === 'initiator') {
-
-          self.server._peers.push(url);
-
-          var newPeer = {
-            url: url,
-            direction: 'initiator',
-            status: 'connecting'
-          }; 
-          
-
-          self.registry.add(newPeer, function(err, newPeer) {
+          self._update(peer, url);
+          peer.url = url;
+          self.registry.save(peer, function(err) {
             if (err) {
               env.response.statusCode = 500;
-              return next(env);
+              next(env);
+              return;
             }
-
-            self.server._runPeer(newPeer);
-            self._disconnect(peer);
             env.response.statusCode = 200;
             next(env);
           });
-
         } else if(peer.direction === 'acceptor') {
           self._proxyDisconnect(env, next, id);
         } else {
@@ -160,6 +149,17 @@ PeerManagementResource.prototype._disconnect = function(peer) {
   });
   var client = peers[0];
   client.close();     
+};
+
+// Update a initiated peer's url
+PeerManagementResource.prototype._update = function(peer, newUrl) {
+  var wsUrl = PeerClient.calculatePeerUrl(peer.url, this.server._name);
+  var peers = this.server._peerClients.filter(function(peer) {
+    return peer.url === wsUrl;  
+  });
+  var client = peers[0];
+  client.updateURL(newUrl);
+  client.ws.close();
 };
 
 PeerManagementResource.prototype._proxyDisconnect = function(env, next, id) { 
@@ -267,28 +267,27 @@ PeerManagementBuilder.prototype.entities = function() {
         }
       };
 
-      entity.actions = [];
-      entity.actions.push({
-        name: 'disconnect',
-        method: 'DELETE',
-        href: self.urlHelper.path('/peer-management/'+peer.connectionId)
-      },{
-        name: 'update',
-        method: 'PUT',
-        href: self.urlHelper.path('/peer-management/'+peer.connectionId),
-        fields: [{name: 'url', type: 'url'}]
-      }); 
+      // For initiator connections show url used
+      if (peer.url) {
+        entity.properties.url = peer.url;
+      }
 
-      /* API action does not work wait till we fix it
-      if (peer.direction === 'initiator') {
+      entity.actions = [];
+
+      // when direction is acceptor, only show actions when connected
+      if (peer.direction === 'initiator' || peer.status === 'connected') {
         entity.actions.push({
-          name: 'reconnect',
-          method: 'POST',
-          href: self.urlHelper.current(),
-          fields: [{ name: 'url', type: 'url', value: peerUrl }]
+          name: 'disconnect',
+          method: 'DELETE',
+          href: self.urlHelper.path('/peer-management/'+peer.connectionId)
+        });
+        entity.actions.push({
+          name: 'update',
+          method: 'PUT',
+          href: self.urlHelper.path('/peer-management/'+peer.connectionId),
+          fields: [{name: 'url', type: 'url'}]
         });
       }
-      */
 
       var peerUrlRel = peer.direction === 'initiator' ? rels.root : rels.server;
       entity.links = [

--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -18,14 +18,11 @@ function calculatePeerUrl(url, name){
 
 
 var PeerClient = module.exports = function(url, server) {
-  var wsUrl = calculatePeerUrl(url, server._name); 
   this.reconnect = {
     min: 100,
     max: 30000, // max amount of time allowed to backoff
     maxRandomOffset: 1000, // max amount of time
   };
-
-  this.url = wsUrl;
 
   this.server = server.httpServer.spdyServer;
   this.connected = false;
@@ -33,6 +30,11 @@ var PeerClient = module.exports = function(url, server) {
   this.log = server.log || new Logger();
   this._backoffTimer = null;
   this._stopped = false;
+
+  // keep a copy of zetta server for calculating it's peer name
+  this._zetta = server;
+
+  this.updateURL(url);
 
   // create a unique connection id peer connection, used to associate initiaion request
   this.connectionId = null;
@@ -43,6 +45,11 @@ var PeerClient = module.exports = function(url, server) {
 util.inherits(PeerClient, EventEmitter);
 
 PeerClient.calculatePeerUrl = calculatePeerUrl;
+
+PeerClient.prototype.updateURL = function(httpUrl) {
+  var wsUrl = calculatePeerUrl(httpUrl, this._zetta._name); 
+  this.url = wsUrl;
+};
 
 PeerClient.prototype._createNewUrl = function() {
   this.connectionId = uuid.v4();

--- a/test/test_peer_connection_api.js
+++ b/test/test_peer_connection_api.js
@@ -105,20 +105,33 @@ describe('Peer Connection API', function() {
       });
     }
 
-    it('exposes actions on the full entity', function(done) {
-      peerRegistry.save({id:'foo', connectionId:'12345'}, function() {
-        var url = '/peer-management/foo';
-        request(getHttpServer(app))
-          .get(url)
-          .expect(getBody(function(res, body) {
-            assert.equal(body.actions.length, 2);
-            body.actions.forEach(function(action) {
-              assert.ok(action.href.indexOf('/peer-management/12345') !== -1);
-            });
-           }))
-           .end(done);
-       });
-    });
+    checkPeersActionsOnFullEntity('initiator', 'connected', 2);
+    checkPeersActionsOnFullEntity('initiator', 'disconnected', 2);
+    checkPeersActionsOnFullEntity('acceptor', 'connected', 2);
+    checkPeersActionsOnFullEntity('acceptor', 'disconnected', 0);
+    
+    function checkPeersActionsOnFullEntity(direction, status, numberOfActionsExpected) {
+      it('when ' + direction + ' exposes ' + numberOfActionsExpected + ' actions on the full entity when ' + status, function(done) {
+        var peer = {
+          id:'foo',
+          connectionId:'12345',
+          direction: direction,
+          status: status
+        };
+        peerRegistry.save(peer, function() {
+          var url = '/peer-management/foo';
+          request(getHttpServer(app))
+            .get(url)
+            .expect(getBody(function(res, body) {
+              assert.equal(body.actions.length, numberOfActionsExpected);
+              body.actions.forEach(function(action) {
+                assert.ok(action.href.indexOf('/peer-management/12345') !== -1);
+              });
+            }))
+            .end(done);
+        });
+      }); 
+    }
   }); 
 
   describe('Root API for peers', function() {


### PR DESCRIPTION
- Removes unsupported websocket link for each peer. Fixes #233
- PUT method now updates the internal peer instead of creating a new peer connection. Fixes #236
- Actions only show on peer entity when it's either an `initiator` or when the status is `connected`. Fixes: #210