### PR TITLE
Only throw an error in the default VirtualDevice callback if an error has been provided.  Fixes #240.

### DIFF
--- a/lib/virtual_device.js
+++ b/lib/virtual_device.js
@@ -96,7 +96,9 @@ VirtualDevice.prototype.call = function(/* transition, args, cb */) {
   } else {
     transitionArgs = args.slice(1, args.length);
     cb = function(err) {
-      throw err;
+      if (err) {
+        throw err;
+      }
     };
   }
 

--- a/test/test_virtual_device.js
+++ b/test/test_virtual_device.js
@@ -79,6 +79,18 @@ describe('Virtual Device', function() {
   
   describe('.call method', function() {
 
+    it('call should work without a callback function', function(done) {
+      vdevice.call('change')
+      var timer = setTimeout(function() {
+        done(new Error('Faied to recv transition call on detroit device'));
+      }, 100);
+
+      device.on('change', function() {
+        clearTimeout(timer);
+        done();
+      });
+    });
+
     it('call should work without arguments', function(done) {
       vdevice.call('change', function(err) {
         assert.equal(err, null);


### PR DESCRIPTION
See #240.