### PR TITLE
Fixed a test that was causing issues, especially in node@0.10

### DIFF
--- a/test/test_event_ws_connection.js
+++ b/test/test_event_ws_connection.js
@@ -80,25 +80,13 @@ describe('Event Websocket', function() {
 
     it('websocket should connect', function(done) {
       var url = 'ws://' + deviceUrl + '/bar';
-      var error = 0;
-      var open = false;
       var socket = new WebSocket(url);
-      socket.on('open', function(err) {
-        open = true;
-      });
-      socket.on('close', function(err) {
-        open = false;
-      });
-      socket.on('error', function(err) {
-        error++;
-      });
 
-      setTimeout(function() {
+      socket.on('open', function(err) {
         socket.close();
-        assert.equal(error, 0);
-        assert.equal(open, true, 'ws should be opened');
         done();
-      }, 20);
+      });
+      socket.on('error', done);
     });
 
   });
@@ -213,26 +201,10 @@ describe('Event Websocket', function() {
 
     it('websocket should connect and recv data in json form', function(done) {
       var url = 'ws://' + deviceUrl + '/bar';
-      var error = 0;
-      var open = false;
       var socket = new WebSocket(url);
+
       socket.on('open', function(err) {
-        open = true;
-      });
-      socket.on('close', function(err) {
-        open = false;
-      });
-      socket.on('error', function(err) {
-        error++;
-      });
-
-      setTimeout(function() {
-
-        assert.equal(error, 0);
-        assert.equal(open, true, 'ws should be opened');
-
         var recv = 0;
-        var timer = null;
         socket.on('message', function(buf, flags) {
           var msg = JSON.parse(buf);
           recv++;
@@ -240,7 +212,6 @@ describe('Event Websocket', function() {
           assert(msg.topic);
           assert.equal(msg.data, recv);
           if (recv === 3) {
-            clearTimeout(timer);
             socket.close();
             done();
           }
@@ -249,36 +220,14 @@ describe('Event Websocket', function() {
         device.incrementStreamValue();
         device.incrementStreamValue();
         device.incrementStreamValue();
-
-        timer = setTimeout(function() {
-          assert.equal(recv, 3, 'should have received 3 messages');
-          socket.close();
-          done();
-        }, 100);
-
-      }, 20);
+      });
+      socket.on('error', done);
     });
 
     it('websocket should connect and recv device log events from property API updates', function(done) {
       var url = 'ws://' + deviceUrl + '/logs';
-      var error = 0;
-      var open = false;
       var socket = new WebSocket(url);
       socket.on('open', function(err) {
-        open = true;
-        
-      });
-      socket.on('close', function(err) {
-        open = false;
-      });
-      socket.on('error', function(err) {
-        error++;
-      });
-
-      setTimeout(function() {
-        assert.equal(error, 0);
-        assert.equal(open, true, 'ws should be opened');
-
         deviceUrlHttp = 'http://' + deviceUrlHttp; 
         var parsed = urlParse(deviceUrlHttp); 
         var reqOpts = {
@@ -295,7 +244,6 @@ describe('Event Websocket', function() {
         req.write(JSON.stringify({ fu: 'bar' }));
         req.end();
         var recv = 0;
-        var timer = null;
         socket.on('message', function(buf, flags) {
           var msg = JSON.parse(buf);
           recv++;
@@ -306,35 +254,20 @@ describe('Event Websocket', function() {
           assert.equal(msg.properties.foo, 0);
 
           if (recv === 1) {
-            clearTimeout(timer);
             socket.close();
             done();
           }
         });
-      }, 20);
+      });
+      socket.on('error', done);
     });
 
     it('websocket should connect and recv device log events', function(done) {
       var url = 'ws://' + deviceUrl + '/logs';
-      var error = 0;
-      var open = false;
       var socket = new WebSocket(url);
+
       socket.on('open', function(err) {
-        open = true;
-      });
-      socket.on('close', function(err) {
-        open = false;
-      });
-      socket.on('error', function(err) {
-        error++;
-      });
-
-      setTimeout(function() {
-        assert.equal(error, 0);
-        assert.equal(open, true, 'ws should be opened');
-
         var recv = 0;
-        var timer = null;
         socket.on('message', function(buf, flags) {
           var msg = JSON.parse(buf);
           recv++;
@@ -347,20 +280,13 @@ describe('Event Websocket', function() {
           assert.equal(msg.actions[0].href.replace('http://',''), deviceUrlHttp)
 
           if (recv === 1) {
-            clearTimeout(timer);
             socket.close();
             done();
           }
         });
 
         device.call('change');
-
-        timer = setTimeout(function() {
-          assert.equal(recv, 1, 'should have received 1 message');
-          socket.close();
-          done();
-        }, 100);
-      }, 20);
+      });
     });
 
     it('websocket should recv connect and disconnect message for /peer-management', function(done) {
@@ -394,33 +320,15 @@ describe('Event Websocket', function() {
 
     it('websocket should connect and recv data in binary form', function(done) {
       var url = 'ws://' + deviceUrl + '/foobar';
-      var error = 0;
-      var open = false;
       var socket = new WebSocket(url);
       socket.on('open', function(err) {
-        open = true;
-      });
-      socket.on('close', function(err) {
-        open = false;
-      });
-      socket.on('error', function(err) {
-        error++;
-      });
-
-      setTimeout(function() {
-
-        assert.equal(error, 0);
-        assert.equal(open, true, 'ws should be opened');
-
         var recv = 0;
-        var timer = null;
         socket.on('message', function(buf, flags) {
           assert(Buffer.isBuffer(buf));
           assert(flags.binary);
           recv++;
           assert.equal(buf[0], recv);
           if (recv === 3) {
-            clearTimeout(timer);
             socket.close();
             done();
           }
@@ -429,14 +337,8 @@ describe('Event Websocket', function() {
         device.incrementFooBar();
         device.incrementFooBar();
         device.incrementFooBar();
-
-        timer = setTimeout(function() {
-          assert.equal(recv, 3, 'should have received 3 messages');
-          socket.close();
-          done();
-        }, 100);
-
-      }, 20);
+      });
+      socket.on('error', done);
     });
 
   });


### PR DESCRIPTION
Fixes an issue with subscribe's callback to peer events being fired multiple times during the test suite. Most of the time the second call was a result of a peer timing out or reconnecting and firing a second _peer/disconnect.

This fixes only two problem test cases. Anytime we call pubsub.subscribe on '_peer/connect' and `_peer/disconnect` we may have similar issues.

Would be helpful for the tests and zetta in general if we had a pubsub.once() method. Then we wouldn't have to manually unsubscribe to these events in the tests.

