### PR TITLE
Added watchdog for ping going into the peer_client.

### DIFF
--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -2,8 +2,16 @@ var EventEmitter = require('events').EventEmitter;
 var path = require('path');
 var util = require('util');
 var uuid = require('node-uuid');
+var spdy = require('spdy');
 var Logger = require('./logger');
 var WebSocket = require('./web_socket');
+
+// monkey patch spdy connection to get access to ping event
+var originalPingHandler = spdy.Connection.prototype._handlePing;
+spdy.Connection.prototype._handlePing = function() {
+  this.socket.emit('spdyPing', this);
+  originalPingHandler.apply(this, arguments);
+};
 
 function calculatePeerUrl(url, name){
  var wsUrl = url.replace(/^http/, 'ws');
@@ -16,13 +24,15 @@ function calculatePeerUrl(url, name){
   return wsUrl;
 }
 
-
 var PeerClient = module.exports = function(url, server) {
   this.reconnect = {
     min: 100,
     max: 30000, // max amount of time allowed to backoff
     maxRandomOffset: 1000, // max amount of time
   };
+
+  // 3x the interval the peer pings down to the client
+  this.pingTimeout = 30000;
 
   this.server = server.httpServer.spdyServer;
   this.connected = false;
@@ -35,7 +45,7 @@ var PeerClient = module.exports = function(url, server) {
   this._zetta = server;
 
   this.updateURL(url);
-
+  
   // create a unique connection id peer connection, used to associate initiaion request
   this.connectionId = null;
   this.ws = new WebSocket(this._createNewUrl(), {});
@@ -73,6 +83,23 @@ PeerClient.prototype.close = function() {
   clearTimeout(this._backoffTimer);
   this._stopped = true;
   this.ws.close();
+  this._stopPingTimeout();
+};
+
+PeerClient.prototype._resetPingTimeout = function() {
+  var self = this;
+  clearTimeout(this._pingTimer);
+  this._pingTimer = setTimeout(function() {
+    if (self.ws) {
+      self.log.emit('warn', 'peer-client', 'Communication to peer timed out. Reconnecting (' + self.url + ')');
+      self.emit('timeout');
+      self.ws.close();
+    }
+  }, this.pingTimeout);
+};
+
+PeerClient.prototype._stopPingTimeout = function() {
+  clearTimeout(this._pingTimer);
 };
 
 PeerClient.prototype._createSocket = function() {
@@ -86,9 +113,16 @@ PeerClient.prototype._createSocket = function() {
   if (this._stopped) {
     return;
   }
+
+  // stop ping timer until backoff finishes
+  self._stopPingTimeout();
   
   var backoff = this.generateBackoff(this.retryCount);
   this._backoffTimer = setTimeout(function(){
+
+    // start ping timer
+    self._resetPingTimeout();
+
     // create a new connection id
     self.ws.setAddress(self._createNewUrl());
     if (self.retryCount === 0) {
@@ -96,6 +130,10 @@ PeerClient.prototype._createSocket = function() {
         self.checkServerReq();
         self.emit('connecting');  
         self.server.emit('connection', socket);
+        socket.on('spdyPing', function(connection) {
+          // reset ping timer on a spdy ping from the peer
+          self._resetPingTimeout();
+        });
         self.log.emit('log', 'peer-client', 'WebSocket to peer established (' + self.url + ')');
       });
 


### PR DESCRIPTION
If no pings are seen coming from the cloud after 30sec disconnect ws and reconnect. Monkey patch is kinda shitty but I couldn't find another way with how spdy doesn't expose the abstract connection that emits ping. Still gotta at some tests.

What's your thoughts on this approach? @mdobson @kevinswiber 