### PR TITLE
Remove Logger 'message' Event Listeners

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -83,6 +83,8 @@ Logger.prototype._sendToPubsub = function(level, event, msg, data) {
 
 function ConsoleOutput(log) {
 
+  log.removeAllListeners(['message']);
+
   function format(level, event, msg, d) {
     var dateStr = Strftime('%b-%d-%Y %H:%M:%S ', new Date(d.timestamp)).green;
     msg = '[' + event + '] ' + msg;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -83,7 +83,7 @@ Logger.prototype._sendToPubsub = function(level, event, msg, data) {
 
 function ConsoleOutput(log) {
 
-  log.removeAllListeners(['message']);
+  log.removeAllListeners('message');
 
   function format(level, event, msg, d) {
     var dateStr = Strftime('%b-%d-%Y %H:%M:%S ', new Date(d.timestamp)).green;


### PR DESCRIPTION
The `ConsoleLog` method of adds a new 'message' event listener to the
provided `Logger` instance. Repeated calls to `ConsoleLog` results in
Node warning of a possible memory leak. It also results in an
increasing number of duplicate log statements.

This change removes all 'message' event listeners of the given `Logger`
instance before adding the new one.

To reproduce: Start a new Zetta server. On a regular interval, stop all
`_peerClients` and call `listen` again.

(Add `this.setMaxListeners(2);` to `init` to shorten time to reproduce)