### PR TITLE
Send 404 on ws that are not handled by zetta or an extension

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -44,22 +44,22 @@ var ZettaHttpServer = module.exports = function(zettaInstance) {
     ssl: false
   });
 
+  var ValidWSUrls = [
+      /^\/events$/, // /events
+      /^\/events?(.+)$/, // /events?topic=query:where type="led"
+      /^\/servers\/(.+)\/events/, // /servers/BC2832FD-9437-4473-A4A8-AC1D56B12C61/events
+      /^\/peers\/(.+)$/, // /peers/123123...
+      /^\/peer-management$/, // /peer-management
+  ];
+  
+  function match(request) {
+    return ValidWSUrls.some(function(re) {
+      return re.test(request.url);
+    });
+  }
+
   this.wss = new WebSocketServer({ noServer: true });
   this.server.on('upgrade', function(request, socket, headers) {
-    function match(request) {
-      if(/^\/peers\/(.+)$/.exec(request.url)) {
-        return true; 
-      } else if(request.url === '/peer-management') {
-        return true;
-      } else if(/^\/servers\/(.+)\/events/.exec(request.url)) {
-        return true;
-      } else if(/^\/events/.exec(request.url)) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-
     if(match(request)) {
       self.wss.handleUpgrade(request, socket, headers, function(ws) {
         var match = /^\/peers\/(.+)$/.exec(ws.upgradeReq.url);
@@ -110,6 +110,25 @@ var ZettaHttpServer = module.exports = function(zettaInstance) {
           self.setupEventSocket(ws);
         }
       });
+    } else {
+      // Check any custom websocket paths from extentions
+      var endWith404 = function() {
+        var responseLine = 'HTTP/1.1 404 Server Not Found\r\n\r\n\r\n';
+        socket.end(responseLine);
+      };
+
+      if (self.server.listeners('upgrade').length > 1) {
+        var timer = setTimeout(function() {
+          if (socket.bytesWritten === 0) {
+            endWith404();
+          }
+        }, 5000);
+        socket.on('close', function() {
+          clearTimeout(timer);
+        });
+      } else {
+        endWith404();
+      }
     }
   });
 

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -46,7 +46,7 @@ var ZettaHttpServer = module.exports = function(zettaInstance) {
 
   var ValidWSUrls = [
       /^\/events$/, // /events
-      /^\/events?(.+)$/, // /events?topic=query:where type="led"
+      /^\/events\?.+$/, // /events?topic=query:where type="led"
       /^\/servers\/(.+)\/events/, // /servers/BC2832FD-9437-4473-A4A8-AC1D56B12C61/events
       /^\/peers\/(.+)$/, // /peers/123123...
       /^\/peer-management$/, // /peer-management

--- a/test/test_event_ws_connection.js
+++ b/test/test_event_ws_connection.js
@@ -100,6 +100,20 @@ describe('Event Websocket', function() {
         done();
       });
     });
+
+    it('will return a 404 on non ws urls for /events123123', function(done) {
+      var url = 'ws://localhost:' + port + '/events123123';
+      var socket = new WebSocket(url);
+      socket.on('open', function(err) {
+        done(new Error('Should not be open.'));
+      });
+      socket.on('error', function(err) {
+        assert.equal(err.message, 'unexpected server response (404)');
+        done();
+      });
+    });
+
+
   });
 
   describe('Embedding a websocket server', function() {

--- a/test/test_event_ws_connection.js
+++ b/test/test_event_ws_connection.js
@@ -70,7 +70,7 @@ describe('Event Websocket', function() {
 
 
   describe('Basic Connection', function() {
-
+    this.timeout(6000);
     it('http resource should exist with statusCode 200', function(done) {
       http.get('http://'+deviceUrlHttp, function(res) {
         assert.equal(res.statusCode, 200);
@@ -89,9 +89,21 @@ describe('Event Websocket', function() {
       socket.on('error', done);
     });
 
+    it('will return a 404 on non ws urls', function(done) {
+      var url = 'ws://localhost:' + port + '/not-a-endpoint';
+      var socket = new WebSocket(url);
+      socket.on('open', function(err) {
+        done(new Error('Should not be open.'));
+      });
+      socket.on('error', function(err) {
+        assert.equal(err.message, 'unexpected server response (404)');
+        done();
+      });
+    });
   });
 
   describe('Embedding a websocket server', function() {
+    this.timeout(6000);
     var app = null;
     var port = null;
     var wss = null;
@@ -150,6 +162,18 @@ describe('Event Websocket', function() {
 
       ws.on('open', function open() {
         ws.send('foo');
+      });
+    });
+
+    it('will return a 404 on non ws urls', function(done) {
+      var url = 'ws://localhost:' + port + '/not-a-endpoint';
+      var socket = new WebSocket(url);
+      socket.on('open', function(err) {
+        done(new Error('Should not be open.'));
+      });
+      socket.on('error', function(err) {
+        assert.equal(err.message, 'unexpected server response (404)');
+        done();
       });
     });
 


### PR DESCRIPTION
http_server will wait 5 seconds to see if bytesWritten has gone up for any sockets that are not handled by zetta if bytesWritten is 0 after 5 seconds send 404. It also sends 404 immediately if there is only one listener on the `upgrade` event for the http server.