### PR TITLE
When proxying requests to a hub use piping unless told not to.

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -409,12 +409,6 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
   var self = this;
   var req = env.request;
   var res = env.response;
-  var opts = env.proxyOpts || {};
-
-  var messageId = ++self.idCounter;
-
-  // change this to handle multiple fogs
-  self.clients[messageId] = res;//req.socket; Will need socket for event broadcast.
 
   var parsed = url.parse(req.url);
   var name = decodeURIComponent(parsed.pathname.split('/')[2]);
@@ -432,22 +426,28 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
 
   var agent = env.zettaAgent || peer.agent;
 
-  var opts = { method: req.method, headers: req.headers, path: req.url, agent: agent };
-  var request = http.request(opts, function(response) {
-    var res = self.clients[messageId];
+  var opts = { 
+    method: req.method,
+    headers: req.headers,
+    path: req.url,
+    agent: agent,
+    pipe: true
+  };
+  if (typeof env.proxyOpts === 'object') {
+    Object.keys(env.proxyOpts).forEach(function(k) {
+      opts[k] = env.proxyOpts[k];
+    });
+  }
 
-    if (!res) {
-      response.statusCode = 404;
-      return;
-    }
+  var request = http.request(opts, function(response) {
 
     Object.keys(response.headers).forEach(function(header) {
       res.setHeader(header, response.headers[header]);
     });
-
+    
     res.statusCode = response.statusCode;
 
-    if(!opts.pipe) {
+    if (!opts.pipe) {
       var body = null;
       var buf = [];
       var len = 0;
@@ -471,18 +471,15 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
           i += chunk.length;
         });
       });
-    } else {
-      response.pipe(res);
-    } 
 
-    response.on('end', function() {
-      if(!opts.pipe) {
+      response.on('end', function() {
         env.response.body = body;
-      }
-      delete self.clients[messageId];
+        next(env);
+      });
+    } else {
+      env.response.body = response;
       next(env);
-    });
-
+    }
   }).on('error', function(err) {
     env.response.statusCode = 502;
     return next(env);


### PR DESCRIPTION
This updates the `proxyToPeer` code in `http_server.js` to pipe the response body back to the client unless specifically told not to by `env.proxyOpts` which is only used for cross server device queries.

Also removes the need to keep the res in `httpServer.clients` I think this was leftover from some earlier code but unnecessary when we have the `env.response` object in scope. 