### PR TITLE
ADD: undefined value judgment

### DIFF
--- a/lib/virtual_device.js
+++ b/lib/virtual_device.js
@@ -139,8 +139,9 @@ VirtualDevice.prototype._update = function(entity) {
   Object.keys(entity.properties).forEach(function(prop) {
     self[prop] = entity.properties[prop];
   });
-  this._actions = entity.actions;
-
+  if(entity.actions) {
+    this._actions = entity.actions;
+  }
   if(entity.links) {
     this._links = entity.links;
   }


### PR DESCRIPTION
Solution of Issues #276.

In the following application,
```javascript
module.exports = function(server) {
  var photocellQuery = server.where({ type: 'photocell' });
  var ledQuery = server.where({ type: 'led' });
  server.observe([photocellQuery, ledQuery], function(photocell, led){
    photocell.streams.intensity.on('data', function(m) {
      if(m.data < 0.5) {
        if (led.available('turn-on')) {
          led.call('turn-on');
        }
      } else {
        if (led.available('turn-off')) {
          led.call('turn-off');
       }
     }
   });
});}
```
After [led.call('turn-on');] was called, the following of [virtual_device.js] is called.
```javascript
this._socket.on(logTopic, function(data) {
  self._update(data);
  self._eventEmitter.emit(data.transition);
});
```
But there are no "actions" properties in "data".

Therefore [this._actions = entity.actions;] will be undefined by the following of [virtual_device.js],

```javascript
VirtualDevice.prototype._update = function(entity) {
  var self = this;
  Object.keys(entity.properties).forEach(function(prop) {
    self[prop] = entity.properties[prop];
  });
  this._actions = entity.actions;

  if(entity.links) {
    this._links = entity.links;
  }
};
```
and an error is output by [this._actions.some(function(action) {... ].