### PR TITLE
VirtualDevice expose .available()

### DIFF
--- a/lib/virtual_device.js
+++ b/lib/virtual_device.js
@@ -121,6 +121,27 @@ VirtualDevice.prototype.call = function(/* transition, args, cb */) {
 
 };
 
+VirtualDevice.prototype.available = function(transition) {
+  return !!this._getAction(transition);
+};
+
+VirtualDevice.prototype.transitionsAvailable = function() {
+  return this._actions.map(function(action) { return action.name; });
+};
+
+VirtualDevice.prototype.properties = function() {
+  var properties = {};
+  var self = this;
+  var reserved = ['streams'];
+  Object.keys(self).forEach(function(key) {
+    if (reserved.indexOf(key) === -1 && typeof self[key] !== 'function' && key[0] !== '_') {
+      properties[key] = self[key];
+    }
+  });
+
+  return properties;
+};
+
 VirtualDevice.prototype._encodeData = function(action, transitionArgs) {
   var actionArguments = {};
   action.fields.forEach(function(arg) {

--- a/lib/virtual_device.js
+++ b/lib/virtual_device.js
@@ -125,23 +125,6 @@ VirtualDevice.prototype.available = function(transition) {
   return !!this._getAction(transition);
 };
 
-VirtualDevice.prototype.transitionsAvailable = function() {
-  return this._actions.map(function(action) { return action.name; });
-};
-
-VirtualDevice.prototype.properties = function() {
-  var properties = {};
-  var self = this;
-  var reserved = ['streams'];
-  Object.keys(self).forEach(function(key) {
-    if (reserved.indexOf(key) === -1 && typeof self[key] !== 'function' && key[0] !== '_') {
-      properties[key] = self[key];
-    }
-  });
-
-  return properties;
-};
-
 VirtualDevice.prototype._encodeData = function(action, transitionArgs) {
   var actionArguments = {};
   action.fields.forEach(function(arg) {

--- a/test/test_virtual_device.js
+++ b/test/test_virtual_device.js
@@ -349,20 +349,6 @@ describe('Virtual Device', function() {
       assert.equal(device.available('turn-on'), true);
       assert.equal(device.available('turn-off'), false);
     });
-
-    it('exposes .properties() method', function() {
-      assert.equal(typeof device.properties, 'function');
-      var properties = device.properties();
-      assert.equal(properties.id, device.id);
-      assert.equal(properties.name, device.name);
-      assert.equal(properties.state, device.state);
-      assert.equal(properties.type, device.type);
-    });
-
-    it('exposes .transitionsAvailable() method', function() {
-      assert.equal(typeof device.transitionsAvailable, 'function');
-      assert.deepEqual(device.transitionsAvailable(), ['turn-on']);
-    });
   });
 
 });

--- a/test/test_virtual_device.js
+++ b/test/test_virtual_device.js
@@ -342,7 +342,27 @@ describe('Virtual Device', function() {
       assert.ok(data);
       assert.equal(Object.keys(data)[0], 'action');
       assert.equal(data.action, 'turn-on');
-    }); 
+    });
+
+    it('exposes .available() method', function() {
+      assert.equal(typeof device.available, 'function');
+      assert.equal(device.available('turn-on'), true);
+      assert.equal(device.available('turn-off'), false);
+    });
+
+    it('exposes .properties() method', function() {
+      assert.equal(typeof device.properties, 'function');
+      var properties = device.properties();
+      assert.equal(properties.id, device.id);
+      assert.equal(properties.name, device.name);
+      assert.equal(properties.state, device.state);
+      assert.equal(properties.type, device.type);
+    });
+
+    it('exposes .transitionsAvailable() method', function() {
+      assert.equal(typeof device.transitionsAvailable, 'function');
+      assert.deepEqual(device.transitionsAvailable(), ['turn-on']);
+    });
   });
 
 });


### PR DESCRIPTION
Implements the `available()` on VirtualDevice to match methods exposed on Device. Fixes #278 

`.available()` returns state based on what the cloud thinks the state of the device is on a hub getting info from logs topic stream and the return from a transition call. There could be times where the state does not line up.