### PR TITLE
Handle Server Listen Error Event

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -67,7 +67,7 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
       /^\/peers\/(.+)$/, // /peers/123123...
       /^\/peer-management$/, // /peer-management
   ];
-  
+
   function match(request) {
     return ValidWSUrls.some(function(re) {
       return re.test(request.url);
@@ -87,7 +87,7 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
           // Include ._env and ._loader on websocket, allows argo formatters to work used in virtual_device build actions.
           var host = ws.upgradeReq.headers['host']
           self.wireUpWebSocketForEvent(ws, host, '/servers/' + name);
-          
+
           if (self.peers[name] && self.peers[name].state !== PeerSocket.DISCONNECTED) {
             // peer already connected or connecting
             ws.close(4000, 'peer already connected');
@@ -97,7 +97,7 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
           } else {
             var peer = new PeerSocket(ws, name, self.peerRegistry);
             self.peers[name] = peer;
-            
+
             // Events coming from the peers pubsub using push streams
             peer.on('zetta-events', function(topic, data) {
               self.zetta.pubsub.publish(name + '/' + topic, data, true); // Set fromRemote flag to true
@@ -202,9 +202,14 @@ ZettaHttpServer.prototype.init = function(cb) {
 };
 
 ZettaHttpServer.prototype.listen = function() {
+  var cb = arguments[arguments.length - 1];
   this.server.listen.apply(this.server,arguments);
+  this.server.on('error', function(e){
+    if(typeof cb == 'function') cb(e);
+  });
   return this;
 };
+
 
 ZettaHttpServer.prototype.collector = function(name, collector) {
   if(typeof name === 'function'){
@@ -446,7 +451,7 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
 
   var agent = env.zettaAgent || peer.agent;
 
-  var opts = { 
+  var opts = {
     method: req.method,
     headers: req.headers,
     path: req.url,
@@ -464,7 +469,7 @@ ZettaHttpServer.prototype.proxyToPeer = function(env, next) {
     Object.keys(response.headers).forEach(function(header) {
       res.setHeader(header, response.headers[header]);
     });
-    
+
     res.statusCode = response.statusCode;
 
     if (!opts.pipe) {

--- a/zetta.js
+++ b/zetta.js
@@ -203,7 +203,7 @@ Zetta.prototype.listen = function() {
     var cb = function(err) {
       if (err) {
         if (callback) {
-          callback(err);
+          return callback(err);
         } else {
           throw err;
         }


### PR DESCRIPTION
If a port is already occupied, the `net` module will generate an
error event. If a callback is passed to the `ZettaHttpServer`
`listen` method, it will not be called, and the error will
go unhandled.

This update allows callers to `listen` to be able to properly handle
errors generated when starting the server.
