### PR TITLE
tests for hiding underscored transitions from the API and logs stream

### DIFF
--- a/test/fixture/example_driver.js
+++ b/test/fixture/example_driver.js
@@ -18,8 +18,9 @@ TestDriver.prototype.init = function(config) {
     .state('ready')
     .type('testdriver')
     .name('Matt\'s Test Device')
-    .when('ready', { allow: ['change', 'test', 'error', 'test-number', 'test-text', 'test-none', 'test-date'] })
+    .when('ready', { allow: ['_ignore-me', 'change', 'test', 'error', 'test-number', 'test-text', 'test-none', 'test-date'] })
     .when('changed', { allow: ['prepare', 'test', 'error'] })
+    .map('_ignore-me', this._ignoreMe)
     .map('change', this.change)
     .map('prepare', this.prepare)
     .map('test', this.test, [{ name: 'value', type: 'number'}])
@@ -40,6 +41,11 @@ TestDriver.prototype.init = function(config) {
 
 TestDriver.prototype.test = function(value, cb) {
   this.value = value;
+  cb();
+};
+
+TestDriver.prototype._ignoreMe = function(cb) {
+  this.state = 'changed';
   cb();
 };
 

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -612,6 +612,25 @@ describe('Zetta Api', function() {
         .end(done);
     });
 
+
+    it('should not show _underscore transition in API but it should be available in JS', function(done) {
+      // assert that change and _ignore-me are available in current state
+      assert(device.available('_ignore-me'));
+      assert(device.available('change'));
+      request(getHttpServer(app))
+        .get(url)
+        .expect(getBody(function(res, body) {
+          assert(body.actions, 7);
+          // but while change is in the API
+          assert.equal(body.actions[0].name, 'change');
+          for (i = 0; i < body.actions.length; i++) {
+            // _ignore-me is not in the API
+            assert.notEqual(body.actions[i].name, '_ignore-me');
+          }
+        }))
+        .end(done);
+    });
+
     it('device should have action change', function(done) {
       request(getHttpServer(app))
         .get(url)


### PR DESCRIPTION
related to this pull request https://github.com/zettajs/zetta-device/pull/19 on zetta-device.
