### PR TITLE
Show better error message when peering fails.

### DIFF
--- a/lib/web_socket.js
+++ b/lib/web_socket.js
@@ -88,6 +88,12 @@ WebSocket.prototype.start = function() {
   });
 
   var subscription = req.subscribe(function(env) {
+    // Handle non 101 response codes with clearer message
+    if (env.response.statusCode !== 101) {
+      self.emit('error', 'server returned ' + env.response.statusCode);
+      return;
+    }
+
     var serverKey = env.response.headers['sec-websocket-accept'];
     if (typeof serverKey == 'undefined' || serverKey !== expectedServerKey) {
       self.emit('error', 'invalid server key');


### PR DESCRIPTION
Will show a message similar to below when peering fails with non 101 status code.

```
Apr-19-2016 14:49:04 [peer-client] Peer connection error (ws://google.com/peers/milford-1): server returned 404
```