### PR TITLE
Using latest zetta-device deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "zetta-auto-scout": "^0.10.0",
     "zetta-device": "^0.19.0",
     "zetta-events-stream-protocol": "^5.0.0",
-    "zetta-http-device": "^0.5.0",
+    "zetta-http-device": "^0.6.0",
     "zetta-rels": "^0.5.0",
     "zetta-scientist": "^0.7.0",
     "zetta-scout": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "strftime": "~0.8.0",
     "titan": "^1.0.0",
     "ws": "^0.4.31",
-    "zetta-auto-scout": "^0.9.0",
-    "zetta-device": "^0.18.0",
+    "zetta-auto-scout": "^0.10.0",
+    "zetta-device": "^0.19.0",
     "zetta-events-stream-protocol": "^5.0.0",
     "zetta-http-device": "^0.5.0",
     "zetta-rels": "^0.5.0",
-    "zetta-scientist": "^0.6.0",
-    "zetta-scout": "^0.6.0",
+    "zetta-scientist": "^0.7.0",
+    "zetta-scout": "^0.7.0",
     "zetta-streams": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PR to merge in the code moves the device_config.js to the `zetta-device` package. Because of how our deps work there is a number of PRs needed before this can be merged.

All changes are backwards compatible with the scientist throwing a deprecation warning if the Device driver is using a zetta-device version < 0.19.0.

- https://github.com/zettajs/zetta-scientist/pull/6
- https://github.com/zettajs/zetta-device/pull/20
- https://github.com/zettajs/zetta-scout/pull/7
- https://github.com/zettajs/zetta-auto-scout/pull/9

Fixes #290 

