### PR TITLE
Unit Test for "x-forwarded-host" Header

### DIFF
--- a/test/test_api.js
+++ b/test/test_api.js
@@ -82,6 +82,25 @@ describe('Zetta Api', function() {
     peerRegistry = new PeerRegistry();
   });
 
+  it('updates href hosts using x-forwarded-host header', function(done) {
+    var app = zetta({ registry: reg, peerRegistry: peerRegistry  })
+        .silent()
+        .name('local')
+        ._run(function(err) {
+          if (err) {
+            return done(err);
+          }
+
+          request(getHttpServer(app))
+            .get('/')
+            .set('x-forwarded-host', 'google.com')
+            .expect(getBody(function(res, body) {
+              var self = body.links.filter(function(link) { return link.rel.indexOf('self') >= 0; })[0];
+              assert.equal(self.href, 'http://google.com/');
+            }))
+            .end(done);
+        });
+  })
 
   it('allow for x-forwarded-host header to be disabled', function(done) {
     var app = zetta({ registry: reg, peerRegistry: peerRegistry, useXForwardedHostHeader: false  })


### PR DESCRIPTION
Beta 6 release did not update the host values in siren responses to
match the value provided by "x-forwarded-host" header. This PR adds
a unit test to verify correct host values.