### PR TITLE
Peer connect and event websocket connection hooks.

### DIFF
--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -40,6 +40,12 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
 
   this._collectors = {};
 
+  // WS hooks to be called before finishing upgrade
+  this._wsHooks = {
+    peerConnect: [],
+    websocketConnect: []
+  };
+
   // external http(s) server
   var httpOptions = {
     windowSize: 1024 * 1024
@@ -81,54 +87,19 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
 
   this.wss = new WebSocketServer({ noServer: true });
   this.server.on('upgrade', function(request, socket, headers) {
-    if(match(request)) {
+    
+    if (/^\/peers\/(.+)$/.exec(request.url)) {
+      // Handle Peer Request
+      self.wss.handleUpgrade(request, socket, headers, function(ws) {      
+        self.setupPeerSocket(ws);
+      });
+    } else if (match(request)) {
       self.wss.handleUpgrade(request, socket, headers, function(ws) {
-        var match = /^\/peers\/(.+)$/.exec(ws.upgradeReq.url);
-        if (match) {
-          var name = /^\/peers\/(.+)$/.exec(url.parse(ws.upgradeReq.url, true).pathname)[1];
-          name = decodeURI(name);
-          self.zetta.log.emit('log', 'http_server', 'Websocket connection for peer "' + name + '" established.');
-
-          // Include ._env and ._loader on websocket, allows argo formatters to work used in virtual_device build actions.
-          var host = ws.upgradeReq.headers['host']
-          self.wireUpWebSocketForEvent(ws, host, '/servers/' + name);
-          
-          if (self.peers[name] && self.peers[name].state !== PeerSocket.DISCONNECTED) {
-            // peer already connected or connecting
-            ws.close(4000, 'peer already connected');
-          } else if (self.peers[name]) {
-            // peer has been disconnected but has connected before.
-            self.peers[name].init(ws);
-          } else {
-            var peer = new PeerSocket(ws, name, self.peerRegistry);
-            self.peers[name] = peer;
-            
-            // Events coming from the peers pubsub using push streams
-            peer.on('zetta-events', function(topic, data) {
-              self.zetta.pubsub.publish(name + '/' + topic, data, true); // Set fromRemote flag to true
-            });
-
-            peer.on('connected', function() {
-              self.eventBroker.peer(peer);
-              self.zetta.log.emit('log', 'http_server', 'Peer connection established "' + name + '".');
-              self.zetta.pubsub.publish('_peer/connect', { peer: peer });
-            });
-
-            peer.on('error', function(err) {
-              self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
-              self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
-            });
-
-            peer.on('end', function() {
-              self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
-              self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
-            });
-          }
-        } else if (ws.upgradeReq.url === '/peer-management') {
+        if (ws.upgradeReq.url === '/peer-management') {
           var query = [
             { name: self.zetta.id, topic: '_peer/connect' },
             { name: self.zetta.id, topic: '_peer/disconnect' }];
-
+          
           var client = new EventSocket(ws, query);
           self.eventBroker.client(client);
         } else {
@@ -136,6 +107,7 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
         }
       });
     } else {
+      // 404
       // Check any custom websocket paths from extentions
       var endWith404 = function() {
         var responseLine = 'HTTP/1.1 404 Server Not Found\r\n\r\n\r\n';
@@ -155,6 +127,7 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
         endWith404();
       }
     }
+    
   });
 
   this.cloud = titan({useXForwardedHostHeader: this.useXForwardedHostHeader})
@@ -208,6 +181,21 @@ ZettaHttpServer.prototype.init = function(cb) {
 ZettaHttpServer.prototype.listen = function() {
   this.server.listen.apply(this.server,arguments);
   return this;
+};
+
+
+ZettaHttpServer.prototype.onPeerConnect = function(handler) {
+  if (typeof handler !== 'function') {
+    throw new Error('Must supply function as a hook');
+  }
+  this._wsHooks.peerConnect.push(handler);
+};
+
+ZettaHttpServer.prototype.onEventWebsocketConnect = function(handler) {
+  if (typeof handler !== 'function') {
+    throw new Error('Must supply function as a hook');
+  }
+  this._wsHooks.websocketConnect.push(handler);
 };
 
 ZettaHttpServer.prototype.collector = function(name, collector) {
@@ -265,6 +253,49 @@ ZettaHttpServer.prototype.wireUpWebSocketForEvent = function(ws, host, p) {
     parsed.pathname = pathname;
     return url.format(parsed);
   };
+};
+
+ZettaHttpServer.prototype.setupPeerSocket = function(ws) {
+  var self = this;
+  var name = /^\/peers\/(.+)$/.exec(url.parse(ws.upgradeReq.url, true).pathname)[1];
+  name = decodeURI(name);
+  self.zetta.log.emit('log', 'http_server', 'Websocket connection for peer "' + name + '" established.');
+
+  // Include ._env and ._loader on websocket, allows argo formatters to work used in virtual_device build actions.
+  var host = ws.upgradeReq.headers['host']
+  self.wireUpWebSocketForEvent(ws, host, '/servers/' + name);
+  
+  if (self.peers[name] && self.peers[name].state !== PeerSocket.DISCONNECTED) {
+    // peer already connected or connecting
+    ws.close(4000, 'peer already connected');
+  } else if (self.peers[name]) {
+    // peer has been disconnected but has connected before.
+    self.peers[name].init(ws);
+  } else {
+    var peer = new PeerSocket(ws, name, self.peerRegistry);
+    self.peers[name] = peer;
+    
+    // Events coming from the peers pubsub using push streams
+    peer.on('zetta-events', function(topic, data) {
+      self.zetta.pubsub.publish(name + '/' + topic, data, true); // Set fromRemote flag to true
+    });
+
+    peer.on('connected', function() {
+      self.eventBroker.peer(peer);
+      self.zetta.log.emit('log', 'http_server', 'Peer connection established "' + name + '".');
+      self.zetta.pubsub.publish('_peer/connect', { peer: peer });
+    });
+
+    peer.on('error', function(err) {
+      self.zetta.log.emit('log', 'http_server', 'Peer connection failed for "' + name + '".');
+      self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+    });
+
+    peer.on('end', function() {
+      self.zetta.log.emit('log', 'http_server', 'Peer connection closed for "' + name + '".');
+      self.zetta.pubsub.publish('_peer/disconnect', { peer: peer });
+    });
+  }
 };
 
 ZettaHttpServer.prototype.setupEventSocket = function(ws) {

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -88,44 +88,64 @@ var ZettaHttpServer = module.exports = function(zettaInstance, options) {
   this.wss = new WebSocketServer({ noServer: true });
   this.server.on('upgrade', function(request, socket, headers) {
     
-    if (/^\/peers\/(.+)$/.exec(request.url)) {
-      // Handle Peer Request
-      self.wss.handleUpgrade(request, socket, headers, function(ws) {      
-        self.setupPeerSocket(ws);
-      });
-    } else if (match(request)) {
-      self.wss.handleUpgrade(request, socket, headers, function(ws) {
-        if (ws.upgradeReq.url === '/peer-management') {
-          var query = [
-            { name: self.zetta.id, topic: '_peer/connect' },
-            { name: self.zetta.id, topic: '_peer/disconnect' }];
-          
-          var client = new EventSocket(ws, query);
-          self.eventBroker.client(client);
-        } else {
-          self.setupEventSocket(ws);
-        }
-      });
-    } else {
-      // 404
+    var sendError = function(code) {
       // Check any custom websocket paths from extentions
-      var endWith404 = function() {
-        var responseLine = 'HTTP/1.1 404 Server Not Found\r\n\r\n\r\n';
+      var finish = function() {
+        var responseLine = 'HTTP/1.1 ' + code + ' ' + http.STATUS_CODES[code] + '\r\n\r\n\r\n';
         socket.end(responseLine);
       };
 
       if (self.server.listeners('upgrade').length > 1) {
         var timer = setTimeout(function() {
           if (socket.bytesWritten === 0) {
-            endWith404();
+            finish();
           }
         }, 5000);
         socket.on('close', function() {
           clearTimeout(timer);
         });
       } else {
-        endWith404();
+        finish();
       }
+    };
+    
+    if (/^\/peers\/(.+)$/.exec(request.url)) {
+      async.eachSeries(self._wsHooks.peerConnect, function(handler, next) {
+        return handler(request, socket, headers, next);
+      }, function(err) {
+        if (err) {
+          return sendError(500);
+        }
+
+        // Handle Peer Request
+        self.wss.handleUpgrade(request, socket, headers, function(ws) {      
+          self.setupPeerSocket(ws);
+        });
+      });
+    } else if (match(request)) {
+      async.eachSeries(self._wsHooks.websocketConnect, function(handler, next) {
+        return handler(request, socket, headers, next);
+      }, function(err) {
+        if (err) {
+          return sendError(500);
+        }
+
+        self.wss.handleUpgrade(request, socket, headers, function(ws) {
+          if (ws.upgradeReq.url === '/peer-management') {
+            var query = [
+              { name: self.zetta.id, topic: '_peer/connect' },
+              { name: self.zetta.id, topic: '_peer/disconnect' }];
+            
+            var client = new EventSocket(ws, query);
+            self.eventBroker.client(client);
+          } else {
+            self.setupEventSocket(ws);
+          }
+        });
+      });
+    } else {
+      // 404
+      sendError(404);
     }
     
   });


### PR DESCRIPTION
Implements #314

```js
.use(function() {
  // Peer connection
  server.httpServer.onPeerConnect(function(request, socket, head, next) {
    // Handle auth logic, 
    next(); // Continue the peering process
    // or
    next(new Error('Some error')); // Response to peer will be 500
  })

  // Regular data websocket connections
  server.httpServer.onEventWebsocketConnect(function(request, socket, head, next) {
    // Handle auth logic, 
    next(); // Continue the event_socket process
    // or
    next(new Error('Some error')); // Response to client will be 500
  })
})
```

It also allows for multiple hooks for each event by calling the method more than once. In that case each hook is called in series.

