### PR TITLE
Emit and Publish Peer Connection Errors

### DIFF
--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -79,11 +79,11 @@ var EventSocket = module.exports = function(ws, query, streamEnabled) {
           self._queryCache[topic.streamQuery] = compiled;
         } catch(err) {
           var msg = {
-            type: 'error', 
+            type: 'error',
             code: 400,
             timestamp: new Date().getTime(),
             topic: msg.topic,
-            message: err.message  
+            message: err.message
           }
           self.ws.send(JSON.stringify(msg));
           return;
@@ -105,7 +105,7 @@ var EventSocket = module.exports = function(ws, query, streamEnabled) {
 
     this._parser.on('unsubscribe', function(msg) {
       self._unsubscribe(msg.subscriptionId, function(err, subscription) {
-        if (subscription) { 
+        if (subscription) {
           self.emit('unsubscribe', subscription);
         }
       });
@@ -180,10 +180,15 @@ EventSocket.prototype.send = function(topic, data) {
 
     // used for _peer/connect _peer/disconnect
     if (topic.indexOf('_peer/') === 0 && typeof tmpData.peer === 'object') {
+      var properties = tmpData.peer.properties();
+      if (tmpData.error) {
+        properties.error = tmpData.error;
+      }
+
       if (this.streamEnabled) {
-        data.data = tmpData.peer.properties();
+        data.data = properties;
       } else {
-        data = ObjectStream.format(topic, tmpData.peer.properties());
+        data = ObjectStream.format(topic, properties);
       }
     }
 

--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -141,7 +141,6 @@ PeerClient.prototype._createSocket = function() {
         self.connected = false;
         self.log.emit('log', 'peer-client', 'Peer connection error (' + self.url + '): ' + err);
         self.emit('error', err);
-        self.emit('closed');
         reconnect(err);
       });
 

--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -20,7 +20,7 @@ function calculatePeerUrl(url, name){
     wsUrl = wsUrl + peerPath;
   } else {
     wsUrl = wsUrl.slice(0, wsUrl.length - 1) + peerPath;
-  } 
+  }
   return wsUrl;
 }
 
@@ -45,7 +45,7 @@ var PeerClient = module.exports = function(url, server) {
   this._zetta = server;
 
   this.updateURL(url);
-  
+
   // create a unique connection id peer connection, used to associate initiaion request
   this.connectionId = null;
   this.ws = new WebSocket(this._createNewUrl(), {});
@@ -57,7 +57,7 @@ util.inherits(PeerClient, EventEmitter);
 PeerClient.calculatePeerUrl = calculatePeerUrl;
 
 PeerClient.prototype.updateURL = function(httpUrl) {
-  var wsUrl = calculatePeerUrl(httpUrl, this._zetta._name); 
+  var wsUrl = calculatePeerUrl(httpUrl, this._zetta._name);
   this.url = wsUrl;
 };
 
@@ -116,7 +116,7 @@ PeerClient.prototype._createSocket = function() {
 
   // stop ping timer until backoff finishes
   self._stopPingTimeout();
-  
+
   var backoff = this.generateBackoff(this.retryCount);
   this._backoffTimer = setTimeout(function(){
 
@@ -128,7 +128,7 @@ PeerClient.prototype._createSocket = function() {
     if (self.retryCount === 0) {
       self.ws.on('open', function onOpen(socket) {
         self.checkServerReq();
-        self.emit('connecting');  
+        self.emit('connecting');
         self.server.emit('connection', socket);
         socket.on('spdyPing', function(connection) {
           // reset ping timer on a spdy ping from the peer
@@ -140,6 +140,7 @@ PeerClient.prototype._createSocket = function() {
       self.ws.on('error', function onError(err) {
         self.connected = false;
         self.log.emit('log', 'peer-client', 'Peer connection error (' + self.url + '): ' + err);
+        self.emit('error', err);
         self.emit('closed');
         reconnect(err);
       });
@@ -177,7 +178,7 @@ PeerClient.prototype.checkServerReq = function() {
       self.retryCount = 0;
       self.emit('connected');
       self.log.emit('log', 'peer-client', 'Peer connection established (' + self.url + ')');
-      
+
       res.statusCode = 200;
       res.end();
 
@@ -195,7 +196,7 @@ PeerClient.prototype.generateBackoff = function(attempt) {
   if (attempt === 0) {
     return 0;
   }
-  
+
   var random = parseInt(Math.random() * this.reconnect.maxRandomOffset);
   var backoff = (Math.pow(2, attempt) * this.reconnect.min);
   if (backoff > this.reconnect.max) {

--- a/test/test_peer_client.js
+++ b/test/test_peer_client.js
@@ -1,8 +1,19 @@
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
 var PeerClient = require('../lib/peer_client');
 var assert = require('assert');
 
 
-var MockServer = { _name: '1234', httpServer: { spdyServer: {}}, log: {}};
+var MockServer = { _name: '1234', httpServer: { spdyServer: {}}, log: {
+  emit: function() {}
+}};
+var MockSocket = function() {
+  EventEmitter.call(this);
+  this.setAddress = function() {};
+  this.start = function() {};
+};
+util.inherits(MockSocket, EventEmitter);
+
 var urlEndingWithSlash = 'http://cloud.zettajs.io/';
 var urlEndingWithNoSlash = 'http://cloud.zettajs.io';
 
@@ -16,6 +27,41 @@ describe('Peer Client', function() {
     it('should calculate the proper url without a trailing slash', function() {
       var client = new PeerClient(urlEndingWithNoSlash, MockServer); 
       assert.equal(client.url, 'ws://cloud.zettajs.io/peers/1234');
-    });
+    });    
   });
+
+  it('should emit error when underlying ws does', function(done) {
+    var client = new PeerClient(urlEndingWithNoSlash, MockServer);
+    client.ws = new MockSocket();
+    client._createSocket();
+    client.once('error', function(err) {
+      assert.equal(err.message, 'some message');
+      done();
+    });
+
+    client.once('closed', function() {
+      done(new Error('Should not have emitted closed'));
+    });
+
+    setTimeout(function() {
+      client.ws.emit('error', new Error('some message'));
+    }, 2);
+  })
+
+  it('should emit closed when underlying ws does', function(done) {
+    var client = new PeerClient(urlEndingWithNoSlash, MockServer);
+    client.ws = new MockSocket();
+    client._createSocket();
+    client.once('error', function(err) {
+      done(new Error('Should not have emitted error'));
+    });
+
+    client.once('closed', function() {
+      done();
+    });
+
+    setTimeout(function() {
+      client.ws.emit('close');
+    }, 2);
+  })
 });

--- a/zetta.js
+++ b/zetta.js
@@ -450,7 +450,7 @@ Zetta.prototype._runPeer = function(peer) {
       self.peerRegistry.save(result);
 
       // peer-event
-      self.pubsub.publish('_peer/disconnect', { peer: peerClient });
+      self.pubsub.publish('_peer/disconnect', { peer: peerClient, error: error });
     });
   });
 

--- a/zetta.js
+++ b/zetta.js
@@ -450,7 +450,7 @@ Zetta.prototype._runPeer = function(peer) {
       self.peerRegistry.save(result);
 
       // peer-event
-      self.pubsub.publish('_peer/disconnect', { peer: peerClient, error: error });
+      self.pubsub.publish('_peer/error', { peer: peerClient, error: error });
     });
   });
 

--- a/zetta.js
+++ b/zetta.js
@@ -450,7 +450,7 @@ Zetta.prototype._runPeer = function(peer) {
       self.peerRegistry.save(result);
 
       // peer-event
-      self.pubsub.publish('_peer/error', { peer: peerClient, error: error });
+      self.pubsub.publish('_peer/disconnect', { peer: peerClient, error: error });
     });
   });
 


### PR DESCRIPTION
Incorporates changes from #312 and includes tests.

`_peer/disconnect` message will container `error` property if PeerClient disconnected with an error. This will also be persisted in the peer registry.
