### PR TITLE
Multiplex ws allow duplicate messages to be filtered

### DIFF
--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -153,7 +153,7 @@ EventBroker.prototype._publishStreamEnabledClient = function(client, query, topi
     newMsg.topic = query.original.hash();
   }
   
-  if (data.data) {
+  if (data.data !== undefined) {
     newMsg.data = data.data;
   } else {
     // handle device and server /logs stream

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -138,12 +138,15 @@ EventBroker.prototype._publishNonStreamEnabledClient = function(client, query, t
 };
 
 EventBroker.prototype._publishStreamEnabledClient = function(client, query, topic, data, sourceTopic, fromRemote) {
+
+  var origData = data;
+  
   var newMsg = {};
   newMsg.type = 'event';
   newMsg.topic = sourceTopic;
   newMsg.timestamp = data.timestamp;
   newMsg.subscriptionId = query.subscriptionId;
-  
+
   if (data.data) {
     newMsg.data = data.data;
   } else {
@@ -173,6 +176,23 @@ EventBroker.prototype._publishStreamEnabledClient = function(client, query, topi
     client.emit('unsubscribe', query);
     client._unsubscribe(query.subscriptionId)
     return;
+  }
+
+  if (client.filterMultiple) {
+    var found = client.hasBeenSent(origData);
+    console.log(sourceTopic, found)
+    if (!found) {
+      var subscriptionsIds = [];
+      client._subscriptions.forEach(function(subscription) {
+        if (subscription.topic.match(sourceTopic)) {
+          subscriptionsIds.push(subscription.subscriptionId);
+        }
+      });
+
+      data.subscriptionId = subscriptionsIds;
+    } else {
+      return 
+    }
   }
 
   client.send(sourceTopic, data, function(err){

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -144,9 +144,15 @@ EventBroker.prototype._publishStreamEnabledClient = function(client, query, topi
   var newMsg = {};
   newMsg.type = 'event';
   newMsg.topic = sourceTopic;
-  newMsg.timestamp = data.timestamp;
+  newMsg.timestamp = data.timestamp || new Date().getTime();
   newMsg.subscriptionId = query.subscriptionId;
 
+  // check if topic is a device query, rewrite sent topic as the original topic
+  var qt = querytopic.parse(query.original.pubsubIdentifier());
+  if (qt) {
+    newMsg.topic = query.original.hash();
+  }
+  
   if (data.data) {
     newMsg.data = data.data;
   } else {
@@ -229,6 +235,13 @@ EventBroker.prototype._streamEnabledClient = function(client) {
       count: 0,
       caql: subscription.topic.streamQuery
     };
+
+    // If topic is a device query appened unique identifier to query
+    var qt = querytopic.parse(query.topic);
+    if (qt) {
+      query.topic = querytopic.format(qt);
+    }
+    
     client.query.push(query);
 
     var connectedPeers = [];

--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -177,21 +177,25 @@ EventBroker.prototype._publishStreamEnabledClient = function(client, query, topi
     client._unsubscribe(query.subscriptionId)
     return;
   }
-
   if (client.filterMultiple) {
-    var found = client.hasBeenSent(origData);
-    console.log(sourceTopic, found)
-    if (!found) {
+    // If query has caql statement don't filter
+    if (query.caql !== null) {
+      data.subscriptionId = [data.subscriptionId];
+    } else {  
+      var found = client.hasBeenSent(origData);
+      if (found) {
+        return;
+      }
+      
       var subscriptionsIds = [];
       client._subscriptions.forEach(function(subscription) {
-        if (subscription.topic.match(sourceTopic)) {
+        // Only provide id if topic matches and topic doesn't have a caql statement
+        if (subscription.topic.match(sourceTopic) && subscription.topic.streamQuery === null) {
           subscriptionsIds.push(subscription.subscriptionId);
         }
       });
 
       data.subscriptionId = subscriptionsIds;
-    } else {
-      return 
     }
   }
 

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -196,7 +196,7 @@ EventSocket.prototype.send = function(topic, data) {
       } else {
         data = tmpData;
       }
-    } else if (data['query']) {
+    } else if (tmpData['query']) {
       // format device queries
       tmpData = deviceFormatter({ loader: this.ws._loader, env: this.ws._env, model: tmpData.device });
       if (this.streamEnabled) {

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -9,8 +9,13 @@ var JSCompiler = require('caql-js-compiler');
 
 //Flag to indicate that we expect data back on teh websocket
 //Tracking subscriptions
-var EventSocket = module.exports = function(ws, query, streamEnabled) {
+var EventSocket = module.exports = function(ws, query, options) {
   EventEmitter.call(this);
+
+  if (options === undefined) {
+    options = {};
+  } 
+  
   this.ws = ws;
   this.query = [];
   this._queryCache = {};
@@ -20,7 +25,7 @@ var EventSocket = module.exports = function(ws, query, streamEnabled) {
   this._subscriptionIndex = 0;
 
   // Flags
-  this.streamEnabled = !!(streamEnabled);
+  this.streamEnabled = !!(options.streamEnabled);
   this.filterMultiple = false;
 
   this.hasBeenSent = function(msg) {
@@ -45,7 +50,7 @@ var EventSocket = module.exports = function(ws, query, streamEnabled) {
     
 
   // only setup parser when using event stream
-  if (streamEnabled) {
+  if (this.streamEnabled) {
     var self = this;
     this._parser = new EventStreamsParser();
     this._parser.on('error', function(err, original) {

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -26,14 +26,13 @@ var EventSocket = module.exports = function(ws, query, options) {
 
   // Flags
   this.streamEnabled = !!(options.streamEnabled);
-  this.filterMultiple = false;
+  this.filterMultiple = !!(options.filterMultiple);
 
   this.hasBeenSent = function(msg) {
     return this._sendBuffer.add(msg);
   };
   this._sendBuffer = {
     add: function(msg) {
-      console.log(this._buffer)
       if (this._buffer.indexOf(msg) >= 0) {
         return true;
       }

--- a/lib/event_socket.js
+++ b/lib/event_socket.js
@@ -18,7 +18,31 @@ var EventSocket = module.exports = function(ws, query, streamEnabled) {
   // list of event streams
   this._subscriptions = [];
   this._subscriptionIndex = 0;
+
+  // Flags
   this.streamEnabled = !!(streamEnabled);
+  this.filterMultiple = false;
+
+  this.hasBeenSent = function(msg) {
+    return this._sendBuffer.add(msg);
+  };
+  this._sendBuffer = {
+    add: function(msg) {
+      console.log(this._buffer)
+      if (this._buffer.indexOf(msg) >= 0) {
+        return true;
+      }
+      
+      if (this._buffer.unshift(msg) > this.max) {
+        this._buffer.pop();
+      }
+
+      return false;
+    },
+    max: 50,
+    _buffer: []
+  };
+    
 
   // only setup parser when using event stream
   if (streamEnabled) {

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -276,7 +276,7 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
     var queryString = url.parse(ws.upgradeReq.url).query;
 
     if(!queryString) {
-      var client = new EventSocket(ws, null, true);
+      var client = new EventSocket(ws, null, { streamEnabled: true });
       self.eventBroker.client(client);
       return;
     }
@@ -301,7 +301,7 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
         if (qt) {
           q.topic = querytopic.format(qt);
         }
-        var client = new EventSocket(ws, q, false);
+        var client = new EventSocket(ws, q, { streamEnabled: false });
         self.eventBroker.client(client);
       }
     });

--- a/lib/http_server.js
+++ b/lib/http_server.js
@@ -273,15 +273,14 @@ ZettaHttpServer.prototype.setupEventSocket = function(ws) {
 
   if (/^\/events/.exec(ws.upgradeReq.url)) {
     self.wireUpWebSocketForEvent(ws, host, '/servers/' + self.zetta._name);
-    var queryString = url.parse(ws.upgradeReq.url).query;
+    var parsed = url.parse(ws.upgradeReq.url, true);
+    var query = parsed.query;
 
-    if(!queryString) {
-      var client = new EventSocket(ws, null, { streamEnabled: true });
+    if(!query.topic) {
+      var client = new EventSocket(ws, null, { streamEnabled: true, filterMultiple: !!(query.filterMultiple) });
       self.eventBroker.client(client);
       return;
     }
-
-    var query = querystring.parse(queryString);
 
     function copy(q) {
       var c = {};

--- a/test/test_event_socket.js
+++ b/test/test_event_socket.js
@@ -69,13 +69,13 @@ describe('EventSocket', function() {
 
   it('should init parser if passed streaming flag', function() {
     var ws = new Ws();
-    var client = new EventSocket(ws, 'some-topic', true);
+    var client = new EventSocket(ws, 'some-topic', { streamEnabled: true });
     assert(client._parser)
   })
 
   it('should emit subscribe event when subscribe message is parsed', function(done) {
     var ws = new Ws();
-    var client = new EventSocket(ws, 'some-topic', true);
+    var client = new EventSocket(ws, 'some-topic', { streamEnabled: true });
     client.on('subscribe', function(subscription) {
       assert(subscription.subscriptionId);
       assert(subscription.topic);

--- a/test/test_event_socket.js
+++ b/test/test_event_socket.js
@@ -73,6 +73,12 @@ describe('EventSocket', function() {
     assert(client._parser)
   })
 
+  it('should pass filterMultiple flag to EventSocket', function() {
+    var ws = new Ws();
+    var client = new EventSocket(ws, 'some-topic', { filterMultiple: true });
+    assert(client.filterMultiple, true);
+  })
+
   it('should emit subscribe event when subscribe message is parsed', function(done) {
     var ws = new Ws();
     var client = new EventSocket(ws, 'some-topic', { streamEnabled: true });

--- a/test/test_event_streams.js
+++ b/test/test_event_streams.js
@@ -1374,6 +1374,124 @@ describe('Event Streams', function() {
       ws.on('error', done);  
     });
 
+    itBoth('Passing filterMultiple options to ws only one data event will be sent', function(idx, done) {
+      var endpoint = urls[idx];
+      var ws = new WebSocket('ws://' + endpoint + baseUrl + '?filterMultiple=true');
+      var topic = validTopics[0];
+      ws.on('open', function() {
+        var msg = { type: 'subscribe', topic: topic };
+        var msg2 = { type: 'subscribe', topic: 'hub/testdriver/*/state' };
+        ws.send(JSON.stringify(msg));
+        ws.send(JSON.stringify(msg2));
+        var subscriptions = [];
+        ws.on('message', function(buffer) {
+          var json = JSON.parse(buffer);
+          if(json.type === 'subscribe-ack') {
+            assert.equal(json.type, 'subscribe-ack');
+            assert(json.timestamp);
+            assert(json.subscriptionId);
+            subscriptions.push(json.subscriptionId);
+            if (subscriptions.length === 2) {
+              setTimeout(function() {
+                devices[0].call('change');
+              }, 50);
+            }
+          } else {
+            assert.equal(json.type, 'event');
+            assert(json.timestamp);
+            assert.equal(json.topic, topic);
+            assert.equal(json.subscriptionId.length, subscriptions.length);
+            subscriptions.forEach(function(id) {
+              assert(json.subscriptionId.indexOf(id) >= -1);
+            });
+            assert(json.data);
+            done();
+          }
+        });
+      });
+      ws.on('error', done);
+    });
+
+    itBoth('Passing filterMultiple options to ws will apply limits for both topics', function(idx, done) {
+      var endpoint = urls[idx];
+      var ws = new WebSocket('ws://' + endpoint + baseUrl + '?filterMultiple=true');
+      var topic = validTopics[0];
+      var topic2 = 'hub/testdriver/*/state';
+      ws.on('open', function() {
+        var msg = { type: 'subscribe', topic: topic, limit: 2 };
+        var msg2 = { type: 'subscribe', topic: topic2, limit: 3 };
+        ws.send(JSON.stringify(msg));
+        ws.send(JSON.stringify(msg2));
+        var subscriptions = {};
+        
+        ws.on('message', function(buffer) {
+          var json = JSON.parse(buffer);
+          if(json.type === 'subscribe-ack') {
+            assert.equal(json.type, 'subscribe-ack');
+            assert(json.timestamp);
+            assert(json.subscriptionId);
+            subscriptions[json.subscriptionId] = 0;
+            if (Object.keys(subscriptions).length === 2) {
+              setTimeout(function() {
+                devices[0].call('change');
+                devices[0].call('prepare');
+                devices[0].call('change');
+              }, 50);
+            }
+          } else if (json.type === 'event') {
+            assert(json.timestamp);
+            assert.equal(json.topic, topic);
+            assert(json.data);
+
+            json.subscriptionId.forEach(function(id) {
+              subscriptions[id]++;
+            });
+
+            if (subscriptions[1] === 2 && subscriptions[2] === 3) {
+              done();
+            }
+          }
+        });
+      });
+      ws.on('error', done);
+    });
+
+    itBoth('Passing filterMultiple options to ws will have no effect on topics with caql query', function(idx, done) {
+      var endpoint = urls[idx];
+      var ws = new WebSocket('ws://' + endpoint + baseUrl + '?filterMultiple=true');
+      var topic = validTopics[0] + '?select *';
+      var topic2 = 'hub/testdriver/*/state';
+      ws.on('open', function() {
+        var msg = { type: 'subscribe', topic: topic };
+        var msg2 = { type: 'subscribe', topic: topic2 };
+        ws.send(JSON.stringify(msg));
+        ws.send(JSON.stringify(msg2));
+        var received = 0;
+        
+        ws.on('message', function(buffer) {
+          var json = JSON.parse(buffer);
+          if(json.type === 'subscribe-ack') {
+            assert.equal(json.type, 'subscribe-ack');
+            assert(json.timestamp);
+            assert(json.subscriptionId);
+            setTimeout(function() {
+              devices[0].call('change');
+            }, 50);
+          } else if (json.type === 'event') {
+            assert(json.timestamp);
+            assert(json.data);
+            assert.equal(json.subscriptionId.length, 1);
+            received++;
+
+            if (received === 2) {
+              done();
+            }
+          }
+        });
+      });
+      ws.on('error', done);
+    });
+
     describe('Protocol Errors', function() {
 
       var makeTopicStringErrorsTest = function(topic) {


### PR DESCRIPTION
Adds `filterMultiple` query parameter to multiplexed ws. If `filterMultiple` is set as a query parameter on `WS /events` then all events that fulfill multiple subscriptions will only be sent once to the client. The `subscriptionId` will always be an array of subscriptions it fulfills.

Eg.

Without `filterMultiple` subscribing to `**` and `*/photocell/*/intensity`
```
λ: wsta ws://localhost:1337/events '{"type": "subscribe", "topic": "**"}' '{"type": "subscribe", "topic": "*/photocell/*/intensity"}'
Connected to ws://localhost:1337/events
{"type":"subscribe-ack","timestamp":1467138805442,"topic":"**","subscriptionId":1}
{"type":"subscribe-ack","timestamp":1467138805442,"topic":"*/photocell/*/intensity","subscriptionId":2}
{"type":"event","topic":"milford/photocell/e7ffb5e3-6961-4d03-8eca-e4267c49af5a/intensity","timestamp":1467138805468,"subscriptionId":1,"data":1.258819045102531}
{"type":"event","topic":"milford/photocell/e7ffb5e3-6961-4d03-8eca-e4267c49af5a/intensity","timestamp":1467138805468,"subscriptionId":2,"data":1.258819045102531}
``` 

With `filterMultiple` subscribing to `**` and `*/photocell/*/intensity`
```
λ: wsta ws://localhost:1337/events?filterMultiple=true '{"type": "subscribe", "topic": "**"}' '{"type": "subscribe", "topic": "*/photocell/*/intensity"}'
Connected to ws://localhost:1337/events?filterMultiple=true
{"type":"subscribe-ack","timestamp":1467138861241,"topic":"**","subscriptionId":1}
{"type":"subscribe-ack","timestamp":1467138861242,"topic":"*/photocell/*/intensity","subscriptionId":2}
{"type":"event","topic":"milford/photocell/e7ffb5e3-6961-4d03-8eca-e4267c49af5a/intensity","timestamp":1467138861259,"subscriptionId":[1,2],"data":0.9999999999999961}
```

Also includes fixes to allow device queries on remote peers to work over multiplexed ws.

Device queries come in the format `{serverName}/query/{query string}`


