### PR TITLE
Custom responses for failed actions

### DIFF
--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -541,7 +541,7 @@ ServerResource.prototype.deviceAction = function(env, next) {
         env.response.statusCode = statusCode;
         env.response.body = {
           class: ['action-error'],
-          properties: err.properties,
+          properties: properties,
           links: [
             { rel: ['self'], href: env.helpers.url.current() }
           ]

--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -17,7 +17,7 @@ ServerResource.prototype.getServer = function(env) {
   var parsed = url.parse(env.request.url);
   var re = /^\/servers\/([^\/]+)/;
   var match = re.exec(parsed.pathname);
-  
+
   var serverId = match && match[1] ? decodeURI(match[1]) : this.server.id;
 
   return { path: '/servers/' + encodeURI(serverId) };
@@ -119,7 +119,7 @@ ServerResource.prototype.subscribe = function(env, next) {
     if (qt) {
       topic = querytopic.format(qt);
       self.server.pubsub.subscribe(topic, env);
-      
+
       setImmediate(function() {
         self.server.httpServer.eventBroker.subscribeToDeviceQuery(topic);
         env.response.on('close', unsubscribe);
@@ -285,7 +285,7 @@ ServerResource.prototype._queryDevices = function(env, next) {
 
     function done() {
       var devices = {};
-        
+
       results.forEach(function(device){
         var deviceOnRuntime = self.server.runtime._jsDevices[device.id];
         if (deviceOnRuntime) {
@@ -299,7 +299,7 @@ ServerResource.prototype._queryDevices = function(env, next) {
         loader: self.getServer(env),
         env: env,
         classes:['search-results'],
-        query: params.ql 
+        query: params.ql
       };
 
       env.format.render('server', context);
@@ -310,7 +310,7 @@ ServerResource.prototype._queryDevices = function(env, next) {
 
 ServerResource.prototype.destroyDevice = function(env, next) {
   if(this.shouldProxy(env)) {
-    return this.proxy(env, next);  
+    return this.proxy(env, next);
   }
 
   var device = this.server.runtime._jsDevices[env.route.params.deviceId];
@@ -338,23 +338,23 @@ ServerResource.prototype.destroyDevice = function(env, next) {
           return next(env);
         } else {
           env.response.statusCode = 204;
-          return next(env); 
+          return next(env);
         }
-      }); 
+      });
     } else {
       env.response.statusCode = 500;
       return next(env);
     }
-     
+
   });
-  
+
 };
 
 ServerResource.prototype.showDevice = function(env, next) {
   if(this.shouldProxy(env)) {
     return this.proxy(env, next);
   }
-  
+
   var device = this.server.runtime._jsDevices[env.route.params.deviceId];
   if(!device) {
     env.response.body = 'Device does not exist';
@@ -447,7 +447,7 @@ ServerResource.prototype.deviceAction = function(env, next) {
     env.response.statusCode = 404;
     return next(env);
   }
-  
+
   env.request.getBody(function(err, body) {
     if (err || !body) {
       env.response.statusCode = 400;
@@ -464,7 +464,7 @@ ServerResource.prototype.deviceAction = function(env, next) {
       env.response.statusCode = 400;
       return next(env);
     }
-    
+
     var action = device._transitions[body.action];
     if (!action) {
       env.response.statusCode = 400;
@@ -475,13 +475,13 @@ ServerResource.prototype.deviceAction = function(env, next) {
       env.response.statusCode = 400;
       return next(env);
     }
-    
+
 
     // device.call(actionName, arg1, arg2, argn, cb);
     var args = [body.action];
 
     if (action.fields && action.fields.length) {
-      
+
       var parseErrors = [];
       action.fields.forEach(function(field) {
         if (field.name !== 'action') {
@@ -505,7 +505,7 @@ ServerResource.prototype.deviceAction = function(env, next) {
         }
       });
 
-      
+
       // Test is any did not decode properly
       if (parseErrors.length > 0) {
         env.response.statusCode = 400;
@@ -525,7 +525,17 @@ ServerResource.prototype.deviceAction = function(env, next) {
 
     var cb = function(err) {
       if (err) {
-        env.response.statusCode = 500;
+        env.response.statusCode = err.statusCode || 500;
+
+        if(err.properties) {
+          env.response.body = {
+            class: ['action-error'],
+            properties: err.properties,
+            links: [
+              { rel: ['self'], href: env.helpers.url.current() }
+            ]
+          };
+        }
       } else {
         var model = {
           model: device,
@@ -535,11 +545,11 @@ ServerResource.prototype.deviceAction = function(env, next) {
         };
         env.format.render('device', model);
       }
-      
+
       next(env);
     };
-    
-    args.push(cb); 
+
+    args.push(cb);
     device.call.apply(device, args);
   }
 };

--- a/lib/api_resources/servers.js
+++ b/lib/api_resources/servers.js
@@ -4,6 +4,7 @@ var MediaType = require('api-media-type');
 var querytopic = require('../query_topic');
 var streams = require('zetta-streams');
 var ObjectStream = streams.ObjectStream;
+var ActionError = require('zetta-device').ActionError;
 
 var ServerResource = module.exports = function(server) {
   this.server = server;
@@ -525,17 +526,26 @@ ServerResource.prototype.deviceAction = function(env, next) {
 
     var cb = function(err) {
       if (err) {
-        env.response.statusCode = err.statusCode || 500;
+        var properties = {};
+        var statusCode = 500;
 
-        if(err.properties) {
-          env.response.body = {
-            class: ['action-error'],
-            properties: err.properties,
-            links: [
-              { rel: ['self'], href: env.helpers.url.current() }
-            ]
-          };
+        if(err instanceof ActionError) {
+          statusCode = err.statusCode;
+          properties = err.properties;
+        } else if (err instanceof Error) {
+          properties.message = err.message;
+        } else if(typeof error === 'string') {
+          properties.message = error
         }
+
+        env.response.statusCode = statusCode;
+        env.response.body = {
+          class: ['action-error'],
+          properties: err.properties,
+          links: [
+            { rel: ['self'], href: env.helpers.url.current() }
+          ]
+        };
       } else {
         var model = {
           model: device,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "titan": "^1.1.0",
     "ws": "^0.4.31",
     "zetta-auto-scout": "^0.10.0",
-    "zetta-device": "^0.19.0",
+    "zetta-device": "^0.20.0",
     "zetta-events-stream-protocol": "^5.0.0",
     "zetta-http-device": "^0.6.0",
     "zetta-rels": "^0.5.0",

--- a/test/fixture/example_driver.js
+++ b/test/fixture/example_driver.js
@@ -40,8 +40,7 @@ TestDriver.prototype.init = function(config) {
 };
 
 TestDriver.prototype.customError = function(cb) {
-
-  cb({statusCode: 401, properties: {message: 'custom error message'}});
+  cb(new Device.ActionError(401, {message: 'custom error message'}))
 }
 
 TestDriver.prototype.test = function(value, cb) {

--- a/test/fixture/example_driver.js
+++ b/test/fixture/example_driver.js
@@ -18,7 +18,7 @@ TestDriver.prototype.init = function(config) {
     .state('ready')
     .type('testdriver')
     .name('Matt\'s Test Device')
-    .when('ready', { allow: ['change', 'test', 'error', 'test-number', 'test-text', 'test-none', 'test-date'] })
+    .when('ready', { allow: ['change', 'test', 'error', 'test-number', 'test-text', 'test-none', 'test-date', 'test-custom-error'] })
     .when('changed', { allow: ['prepare', 'test', 'error'] })
     .map('change', this.change)
     .map('prepare', this.prepare)
@@ -36,7 +36,13 @@ TestDriver.prototype.init = function(config) {
     .map('test-text', function(x, cb) { this.message = x; cb(); }, [{ name: 'value', type: 'text'}])
     .map('test-none', function(x, cb) { cb(); }, [{ name: 'value'}])
     .map('test-date', function(x, cb) { cb(); }, [{ name: 'value', type: 'date'}])
+    .map('test-custom-error', this.customError);
 };
+
+TestDriver.prototype.customError = function(cb) {
+
+  cb({statusCode: 401, properties: {message: 'custom error message'}});
+}
 
 TestDriver.prototype.test = function(value, cb) {
   this.value = value;
@@ -54,7 +60,7 @@ TestDriver.prototype.prepare = function(cb) {
 };
 
 TestDriver.prototype.streamObject = function(stream) {
-  this._streamObject = stream;  
+  this._streamObject = stream;
 };
 
 TestDriver.prototype.returnError = function(error, cb) {
@@ -70,8 +76,8 @@ TestDriver.prototype.incrementStreamValue = function() {
 
 TestDriver.prototype.publishStreamObject = function(obj) {
   if(this._streamObject) {
-    this._streamObject.write(obj);  
-  } 
+    this._streamObject.write(obj);
+  }
 };
 
 TestDriver.prototype.streamBar = function(stream) {

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -771,7 +771,7 @@ describe('Zetta Api', function() {
       request(getHttpServer(app))
         .get(url)
         .expect(getBody(function(res, body) {
-          assert.equal(body.actions.length, 7);
+          assert.equal(body.actions.length, 8);
           var action = body.actions[0];
           assert.equal(action.name, 'change');
           assert.equal(action.method, 'POST');
@@ -785,7 +785,7 @@ describe('Zetta Api', function() {
       request(getHttpServer(app))
         .get(url)
         .expect(getBody(function(res, body) {
-          assert.equal(body.actions.length, 7);
+          assert.equal(body.actions.length, 8);
           body.actions.forEach(function(action) {
             assert(action.class.indexOf('transition') >= 0);
           })
@@ -1044,7 +1044,7 @@ describe('Zetta Api', function() {
         .end(done);
     });
 
-    it.only('should return custom error information when a error is passed in a callback of device driver', function(done) {
+    it('should return custom error information when a error is passed in a callback of device driver', function(done) {
       request(getHttpServer(app))
         .post(url)
         .type('form')

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -1044,6 +1044,23 @@ describe('Zetta Api', function() {
         .end(done);
     });
 
+    it('should return custom error information when a error is passed in a callback of device driver', function(done) {
+      request(getHttpServer(app))
+        .post(url)
+        .type('form')
+        .send({action: 'test-custom-error'})
+        .expect(getBody(function(res, body) {
+          assert.equal(res.statusCode, 401);
+          assert(body.class.indexOf('action-error') >= 0);
+
+          assert(body.properties.message);
+          assert.equal('custom error message', body.properties.message);
+
+          hasLinkRel(body.links, rels.self);
+        }))
+        .end(done);
+    });
+
     it('should support device updates using PUT', function(done) {
       request(getHttpServer(app))
         .put(url)

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -1044,7 +1044,7 @@ describe('Zetta Api', function() {
         .end(done);
     });
 
-    it('should return custom error information when a error is passed in a callback of device driver', function(done) {
+    it.only('should return custom error information when a error is passed in a callback of device driver', function(done) {
       request(getHttpServer(app))
         .post(url)
         .type('form')


### PR DESCRIPTION
We have a couple of cases where we need to know **why** an action failed.  We could come up with some work around with the server log or monitored properties, but that is not an ideal way to handle errors. 

This is written such that existing callbacks will not be affected.  The `err` object must have a "properties" member for the behavior to be triggered.  I also added a test case to validate the Siren response.