### PR TITLE
:arrow_up: Update colors dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "calypso-level": "^0.5.0",
     "calypso-query-decompiler": "^0.4.0",
     "caql-js-compiler": "^0.5.0",
-    "colors": "~0.6.2",
+    "colors": "^1.1.2",
     "levelup": "^0.18.5",
     "medea": "^1.0.0",
     "medeadown": "^1.1.8",


### PR DESCRIPTION
No breaking changes.

It might be a good idea to prefer explicit over implicit though (`colors.green('hello')` instead of `'hello'.green`). I guess this is a matter of taste, but extending prototype does not sound clean to me.