### PR TITLE
Stream Enabled Clients Do Not Need Close Handler

### DIFF
--- a/lib/event_broker.js
+++ b/lib/event_broker.js
@@ -78,7 +78,7 @@ EventBroker.prototype.client = function(client) {
     this._streamEnabledClient(client);
     return;
   }
-  
+
   // query: { name: <serverName>, topic: <pubsub topic>}
   client.query.forEach(function(query) {
     self._subscribe(client, query, self._publishNonStreamEnabledClient.bind(self));
@@ -87,7 +87,7 @@ EventBroker.prototype.client = function(client) {
 
 EventBroker.prototype._subscribe = function(client, query, sendMethod) {
   var self = this;
-  var subscriptionTopic = query.topic; 
+  var subscriptionTopic = query.topic;
   var isRemote = false;
   if (query.name && query.name !== self.zetta.id) {
     isRemote = true;
@@ -122,10 +122,12 @@ EventBroker.prototype._subscribe = function(client, query, sendMethod) {
     }
   };
 
-  client.once('close', function() {
-    unsubscribe();
-  });
-  
+  if(!client.streamEnabled) {
+    client.once('close', function() {
+      unsubscribe();
+    });
+  }
+
   return unsubscribe;
 };
 
@@ -140,7 +142,7 @@ EventBroker.prototype._publishNonStreamEnabledClient = function(client, query, t
 EventBroker.prototype._publishStreamEnabledClient = function(client, query, topic, data, sourceTopic, fromRemote) {
 
   var origData = data;
-  
+
   var newMsg = {};
   newMsg.type = 'event';
   newMsg.topic = sourceTopic;
@@ -152,7 +154,7 @@ EventBroker.prototype._publishStreamEnabledClient = function(client, query, topi
   if (qt) {
     newMsg.topic = query.original.hash();
   }
-  
+
   if (data.data !== undefined) {
     newMsg.data = data.data;
   } else {
@@ -187,12 +189,12 @@ EventBroker.prototype._publishStreamEnabledClient = function(client, query, topi
     // If query has caql statement don't filter
     if (query.caql !== null) {
       data.subscriptionId = [data.subscriptionId];
-    } else {  
+    } else {
       var found = client.hasBeenSent(origData);
       if (found) {
         return;
       }
-      
+
       var subscriptionsIds = [];
       client._subscriptions.forEach(function(subscription) {
         // Only provide id if topic matches and topic doesn't have a caql statement
@@ -241,7 +243,7 @@ EventBroker.prototype._streamEnabledClient = function(client) {
     if (qt) {
       query.topic = querytopic.format(qt);
     }
-    
+
     client.query.push(query);
 
     var connectedPeers = [];
@@ -261,7 +263,7 @@ EventBroker.prototype._streamEnabledClient = function(client) {
 
       if(connectedPeers.indexOf(copiedQuery.name) === -1) {
         connectedPeers.push(copiedQuery.name);
-        
+
         var unsubscribe = self._subscribe(client, copiedQuery, function(client, query, topic, data, sourceTopic, fromRemote) {
 
           // Not a sepcial and topic like _peer/connect and the query is local.
@@ -288,7 +290,7 @@ EventBroker.prototype._streamEnabledClient = function(client) {
       }
     };
 
-    if(query.name instanceof RegExp || query.name === '*') {        
+    if(query.name instanceof RegExp || query.name === '*') {
       var peerConnectSubscription = function(topic, data) {
         // Only subscribe to peer acceptor direction for peers
         if (data.peer.name) {
@@ -330,7 +332,7 @@ EventBroker.prototype._streamEnabledClient = function(client) {
 };
 
 
-// Subscribe to peer has been conneced. If peer is not connected keep a list of topics for 
+// Subscribe to peer has been conneced. If peer is not connected keep a list of topics for
 // when it does connect.
 EventBroker.prototype._subscribeToPeer = function(peerName, topic) {
   var peer = this.peers[peerName];


### PR DESCRIPTION
The call to `EventBroker.prototype.client` checks the given `client`
instance for `streamEnabled`. If "true", the client is passed to
`_streamEnabledClient` where it has "close" and "unsubscribe" event
handlers added. If the client is *not* `streamEnabled` the event
handlers are *not* added.

This means that the `_subscribe` method only needs to make sure to
call unsubscribe on the "close" event of clients that are not
`streamEnabled`.

---

This PR is to address Issue #351 