### PR TITLE
Offers a solution to issue #361 (Allow Server.observe with authenticated peer)

### DIFF
--- a/lib/peer_client.js
+++ b/lib/peer_client.js
@@ -179,6 +179,19 @@ PeerClient.prototype.checkServerReq = function() {
       self.log.emit('log', 'peer-client', 'Peer connection established (' + self.url + ')');
 
       res.statusCode = 200;
+
+      // If the auth flag is set, then that means this connection is authenticated.
+      // We need to pass back the authorization so that the server we're peering to
+      // can connect back to us for subscriptions
+      if ((typeof res.socket.socket.authorized !== 'undefined') && (res.socket.socket.authorized)) {
+        var headers = {
+          'X-Authorization-Required': true,
+          'authorization': res.socket.socket._httpMessage._headers.authorization
+        };
+
+        res.writeHead(res.statusCode, headers);
+      }
+
       res.end();
 
       // remove request listener

--- a/lib/peer_socket.js
+++ b/lib/peer_socket.js
@@ -24,6 +24,7 @@ var PeerSocket = module.exports = function(ws, name, peerRegistry, opts) {
   var self = this;
   this.state = STATES.DISCONNECTED;
   this.name = name; // peers local id
+  this.authorization = null;
   this.agent = null;
   this.subscriptions = {}; // { <topic>: <subscribed_count> }
   this.connectionId = null;
@@ -311,6 +312,10 @@ PeerSocket.prototype.subscribe = function(event, cb) {
     agent: this.agent
   };
 
+  if (this.authorization !== null) {
+    opts.headers.Authorization = this.authorization;
+  }
+
   var req = http.request(opts, function(res) {
     cb();
   }).on('error', cb);
@@ -355,6 +360,10 @@ PeerSocket.prototype.unsubscribe = function(event, cb) {
     agent: this.agent
   };
 
+  if (this.authorization !== null) {
+    opts.headers.Authorization = this.authorization;
+  }
+
   var req = http.request(opts, function(res) {
     cb();
   }).on('error', cb);
@@ -362,6 +371,7 @@ PeerSocket.prototype.unsubscribe = function(event, cb) {
 };
 
 PeerSocket.prototype.confirmConnection = function(connectionId, callback) { 
+  var self = this;
   var timeout = setTimeout(function() {
     req.abort();
     callback(new Error('Confirm connection timeout reached.'));
@@ -373,6 +383,14 @@ PeerSocket.prototype.confirmConnection = function(connectionId, callback) {
     if (res.statusCode !== 200) {
       return callback(new Error('Unexpected status code'));
     }
+  
+    // If the peer has responded with an auth flag, then it is passing back the
+    // authorization to use for future requests.  So we need to store this value
+    // for requests like observe subscribe.
+    if (res.headers['x-authorization-required']) {
+      self.authorization = res.headers.authorization;
+    }
+    
     callback();
   }).on('error', function(err) {
     clearTimeout(timeout);
@@ -403,6 +421,10 @@ PeerSocket.prototype.transition = function(action, args, cb) {
       'Content-Length': body.length,
     }
   };
+
+  if (this.authorization !== null) {
+    opts.headers.Authorization = this.authorization;
+  }
 
   var req = http.request(opts, function(res) {
     var buffer = [];


### PR DESCRIPTION
zetta currently allows for peer link authentication using the hooks server.onPeerRequest, server.onPeerResponse, server.httpServer.onPeerConnect, and server.httpServer.onEventWebsocketConnect.  This allows an initiating peer to make a link request to a receiving peer.  This assumes that any peer wishing to initiate a connection must know the authorization scheme and credentials required for a particular receiver.

However, things are flipped when the receiving peer wishes to establish a connection back to the initiating peer for a Server.observe.  In this situation, it should not be assumed that the receiver knows the authorization scheme and credentials for each and every initiator.  Since the receiver doesn't know how to authenticate with the initiator, Server.observe fails for that peer.

This can be alieviated if the initiating peer simply passes the authorization scheme and credentials to the receiver in the response to the receiver's _initiate_peer request.  The initiator handles the request in the PeerClient.checkServerReq function, and passes back the authorization in the response header.  The receiver in PeerSocket.confirmConnection then keeps track of the authorization if it sees x-authorization-required set in header.

This additional code does not affect processing when peer authentication/authorization is not used.  The reverse-authorization passing should work for any authorization scheme.  One big assumption is that the initiator scheme and credentials will work in reverse -- that's up to the initiator to fulfill, but if not, then it doesn't fail any worse than it does currently.