### PR TITLE
Added npmignore to cut down on package size.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 *.swo
 *.swp
 .DS_Store
-node_modules
 .tern-port
 argo-HEAD
 argo-jscoverage
@@ -14,4 +13,9 @@ zetta-runtime-jscoverage
 .registry
 .peers
 .devices
+.travis.yml
 .vscode
+
+test/
+bin/
+example/


### PR DESCRIPTION
From around 600KB to 147KB

```
npm notice
npm notice 📦  zetta@1.5.1
npm notice === Tarball Contents ===
npm notice 1.6kB  package.json
npm notice 1.1kB  LICENSE
npm notice 2.3kB  README.md
npm notice 364B   zetta_runtime.js
npm notice 11.5kB zetta.js
npm notice 2.6kB  lib/api_formats/siren/device.siren.js
npm notice 1.0kB  lib/api_formats/siren/devices.siren.js
npm notice 1.1kB  lib/api_formats/siren/metadata.siren.js
npm notice 2.3kB  lib/api_formats/siren/server.siren.js
npm notice 733B   lib/api_formats/siren/type.siren.js
npm notice 820B   lib/api_resources/devices.js
npm notice 10.3kB lib/api_resources/peer_management.js
npm notice 9.6kB  lib/api_resources/root.js
npm notice 14.6kB lib/api_resources/servers.js
npm notice 554B   lib/device_registry.js
npm notice 11.3kB lib/event_broker.js
npm notice 7.2kB  lib/event_socket.js
npm notice 683B   lib/http_scout.js
npm notice 16.6kB lib/http_server.js
npm notice 2.6kB  lib/logger.js
npm notice 5.7kB  lib/peer_client.js
npm notice 1.5kB  lib/peer_registry.js
npm notice 10.4kB lib/peer_socket.js
npm notice 5.2kB  lib/pubsub_service.js
npm notice 771B   lib/query_topic.js
npm notice 392B   lib/query.js
npm notice 1.9kB  lib/registration_resource.js
npm notice 3.5kB  lib/registry.js
npm notice 10.2kB lib/runtime.js
npm notice 358B   lib/spdy_agent.js
npm notice 5.3kB  lib/virtual_device.js
npm notice 2.8kB  lib/web_socket.js
npm notice === Tarball Details ===
npm notice name:          zetta
npm notice version:       1.5.1
npm notice package size:  34.8 kB
npm notice unpacked size: 146.7 kB
npm notice shasum:        0cc2f0d39ea371a3cf57bd652904b90df674046c
npm notice integrity:     sha512-Xk4m5/rKH9Fk0[...]hGsCFx7zw8sOA==
npm notice total files:   32
npm notice
```